### PR TITLE
Update the 'Routing and MVC' article

### DIFF
--- a/docs/de/software-entwicklung/add-ons-entwickeln/routing-und-mvc.md
+++ b/docs/de/software-entwicklung/add-ons-entwickeln/routing-und-mvc.md
@@ -1,9 +1,102 @@
-# Routing und MVC
-"
-In diesem Artikel wird darauf eingegangen, wie die i-doit-interne MVC-Struktur funktioniert und wie damit eine eigene GUI realisiert werden kann.
+# Routing in i-doit
 
-URL-Routing
------------
+In diesem Artikel wird darauf eingegangen, wie das i-doit-interne routing funktioniert und wir damit eine eigene GUI realisieren können.
+
+## URL-Routing (Symfony Routing)
+
+Seit i-doit 25 kann die [Symfony Routing Komponente](https://symfony.com/doc/5.4/routing.html) genutzt werden um eigene Endpunkte zu realisieren.
+Dazu müssen die Routen in der `init.php` des Add-ons registriert werden. Dazu kann der neue `'routes'` service genutzt werden.
+
+Die Methode `addCollection` kann genutzt werden um mehrere Routen aus einer `PHP` oder `YAML` Datei zu registrieren:
+
+```php
+
+use idoit\Psr4AutoloaderClass;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\PhpFileLoader;
+
+Psr4AutoloaderClass::factory()->addNamespace('idoit\Module\Example', __DIR__ . '/src/');
+
+isys_application::instance()->container->get('routes')
+    ->addCollection((new PhpFileLoader(new FileLocator(__DIR__)))->load('config/routes.php'));
+```
+
+Die `routes.php` kann dabei folgendermaßen aussehen:
+
+```php
+use idoit\Module\Example\Controller\ExampleController;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->add('example.route', '/example/custom-route')
+        ->methods(['GET'])
+        ->controller([ExampleController::class, 'index']);
+};
+```
+
+Mit diesem Code wird die route `/example/custom-route` registriert. Beim aufruf dieser URL wird der Controller `ExampleController` und dessen Methode `index` aufgerufen.
+
+## Controller Code
+
+Die Symfony Routing Komponente arbeitet mit zwei Klasse `Request` und `Response`. Die Instanz der `Request` Klasse wird der Methode übergeben,
+die Controller Methoden die von Symfony aufgerufen werden müssen `Response` Klassen zurückliefern.
+
+Es gibt (im vergleich zur alten Logik) keine weiteren Abhängigkeiten zu anderen Klassen und/oder Schnittstellen.
+
+### `Response` Objekte
+
+Die aufgerufenen Methoden müssen immer eine `Response` Instanz zurückliefern damit sie verarbeitet werden können.
+Dazu gibt es eine Reihe von verschiedenen `Response` Klassen, die genutzt werden können:
+
+#### Die normale `Response` Klasse
+
+Diese Klasse kann für spezifische Inhalte genutzt werden, die ggf. spezielle `content-type` Angaben oder Response Codes benötigen. 
+
+```php
+$response = new Response(
+    'Content',
+    Response::HTTP_OK,
+    ['content-type' => 'text/html']
+);
+```
+
+#### Für JSON `JsonResponse`
+
+Die `JsonResponse` Klasse kann genutzt werden um Daten im JSON Format an das Frontend zurückzuliefern. Die Klasse wird dabei den korrekten `content-type` setzen und die Umwandlung zum JSON String übernehmen.
+Diese Klasse eignet sich vor allem für Antworten von Ajax Anfragen, die im Frontend weiterverwendet werden können.
+
+```php
+$response = new JsonResponse(['data' => 123]);
+```
+
+#### Die i-doit eigene `IdoitReponse`
+
+Um die i-doit Oberfläche darzustellen kann die `IdoitResponse` genutzt werden, diese beinhaltet alle notwendigen Logiken zum darstellen von eigenen Inhalten und einem Navigationsbaum.
+Es gibt auch ein paar "Convenience" Methoden die von Entwicklern genutzt werden können um bestimmte Verhalten zu forcieren:
+
+```php
+$response = new IdoitResponse('path/to/content-template.tpl');
+
+// Show an additional template at a specific area.
+$response->setTemplate('area', 'path/to/template.tpl');
+
+// Hide the navbar.
+$response->showNavbar(false);
+
+// Render a navigation tree.
+$node = (new Node('Root'))
+    ->add(new Node('Sub Node #1'), 'url-1')
+    ->add(new Node('Sub Node #2'), 'url-2');
+
+$response->setNavigationTree($node):
+```
+
+# Altes Routing und MVC (pre i-doit 25)
+
+Nachfolgend die Dokumentation für die alte Routing und MVC Struktur in i-doit. Diese wird für längere Zeit in i-doit enthalten sein.
+Für neuentwicklungen empfehlen wir aber die neue Routing Möglichkeiten (siehe oben).
+
+## URL-Routing
 
 Mit Hilfe der URL wird das eigene Add-on überhaupt erst angesprochen. Dies geschieht über eine Basis-Route, die folgendermaßen funktioniert:
 
@@ -46,8 +139,7 @@ Die Namen von Actions sind im Gegensatz zu Controllern restriktiver und unterlie
 
     Auf einigen Betriebssystemen (Windows und Mac) wird die Groß- und Kleinschreibung von Controller und Action keinen Unterschied machen. Unter Linux jedoch werden Controller und/oder Actions bei falscher Schreibweise nicht gefunden und werden Fehler verursachen.
 
-Eigene Routen definieren
-------------------------
+## Eigene Routen definieren
 
 Es ist innerhalb der init.php möglich, eigene Routen für das Add-on zu definieren. Der Code dazu sieht folgendermaßen aus:
 
@@ -74,8 +166,7 @@ Wir unterstützen ab i-doit 23 zwei Formate, sodass der Identifier `example_addo
 
 Der vollständige Namespace für die Controller würde also `idoit\Module\ExampleAddon\Controller` lauten, wobei auch der alte Namespace gültig wäre.
 
-Controller-Code
----------------
+## Controller-Code
 
 Ein Controller besteht aus einigem Boilerplate-Code und optionalen eigenen Methoden, wenn man das Routing ausnutzen möchte. Wichtig hierbei ist, dass die korrekten Namespaces eingehalten werden:
 
@@ -181,8 +272,7 @@ In diesem Controller können nun beliebige Methoden ergänzt werden. Es ist alle
 
 Eine Controller-"Action" sollte immer eine View zurückliefern, die das "Renderable"-Interface implementiert.
 
-View-Code
----------
+## View-Code
 
 Die View-Klassen werden benutzt, um unsere Templates vorzubereiten und mit Leben zu füllen. Üblicherweise werden hier darzustellende Templates definiert und mit Variablen befüllt, die im Template-Kontext ausgegeben werden. Eine View-Klasse kann die verschiedenen "Inhaltsbereiche" von i-doit mit eigenen Templates ausstatten. Der normale Content-Bereich hört zum Beispiel auf den Namen "contentbottomcontent" und wird folgendermaßen benutzt:
 


### PR DESCRIPTION
In i-doit 25 we will introduce a new library to handle the internal routing.

This uses the "Symfony Routing" component: https://symfony.com/doc/current/routing.html
And also the HTTP classes for "Request" and "Reponse"