### PR TITLE
added info box for ndoutils command

### DIFF
--- a/docs/de/automatisierung-und-integration/cli/console/optionen-und-parameter-der-console.md
+++ b/docs/de/automatisierung-und-integration/cli/console/optionen-und-parameter-der-console.md
@@ -975,6 +975,9 @@ sudo -u www-data php console.php migrate-uploaded-files
 
 ### nagios-export
 
+!!!info
+    Dieser Befehl ist erst nach installation des Nagios Add-ons verfügbar.
+
 Exportiert die Nagios-Einstellungen und i-doit Objekte in Nagios-Konfigurationsdateien.
 
 **Optionen:**

--- a/docs/de/automatisierung-und-integration/cli/console/optionen-und-parameter-der-console.md
+++ b/docs/de/automatisierung-und-integration/cli/console/optionen-und-parameter-der-console.md
@@ -1002,6 +1002,9 @@ sudo -u www-data php console.php nagios-export --user admin --password admin --t
 
 ### nagios-ndoutils
 
+!!!info
+    Dieser Befehl ist erst nach installation des Nagios Add-ons verfügbar.
+
 Importiert Monitoring Statusänderungen aus den NDOUtils in das i-doit Logbuch.
 
 **Optionen:**

--- a/docs/en/automation-and-integration/cli/console/options-and-parameters-cli.md
+++ b/docs/en/automation-and-integration/cli/console/options-and-parameters-cli.md
@@ -1000,6 +1000,9 @@ sudo -u www-data php console.php nagios-export --user admin --password admin --t
 
 ### nagios-ndoutils
 
+!!!info
+    This Command is only available if the Nagios Add-on is installed
+
 Imports monitoring status changes from the NDOUtils into the i-doit logbook.
 
 **Options:**

--- a/docs/en/automation-and-integration/cli/console/options-and-parameters-cli.md
+++ b/docs/en/automation-and-integration/cli/console/options-and-parameters-cli.md
@@ -973,6 +973,9 @@ sudo -u www-data php console.php migrate-uploaded-files
 
 ### nagios-export
 
+!!!info
+    This Command is only available if the Nagios Add-on is installed
+
 Exports the Nagios settings and i-doit objects to Nagios configuration files
 
 **Options:**


### PR DESCRIPTION
Users seemed to think that the ndoutils command is part of i-doit core. The infobox informs the users that the nagios add-on is required.