### PR TITLE
docs: add SMTP configuration details to admin center documentation

### DIFF
--- a/docs/de/administration/admin-center.md
+++ b/docs/de/administration/admin-center.md
@@ -66,6 +66,12 @@ Bei einem Klick auf den Bereich **Support** wird das <help.i-doit.com></https.he
 
 Hier finden Sie die system bezogenen Einstellungen. Auch finden Sie hier den Link zu den [Experteneinstellungen](#expert-settings-system-related) auf der rechten Seite.
 
+### Login
+
+| Option                    | Wert   |
+| ------------------------- | ------ |
+| Welcome message for login | String |
+
 ### LDAP Debug settings
 
 | Option     | Wert         |
@@ -74,11 +80,22 @@ Hier finden Sie die system bezogenen Einstellungen. Auch finden Sie hier den Lin
 
 Einstellung kann auch via [Expert settings](#expert-settings-system-related) geändert werden. Die Option heißt `ldap.debug`.
 
-### Login
+### SMTP
 
-| Option                    | Wert   |
-| ------------------------- | ------ |
-| Welcome message for login | String |
+| Option         | Wert              |
+| -------------- | ----------------- |
+| SMTP Host      | Hostname oder URL |
+| SMTP Port      | Port              |
+| SMTP Username  | Username          |
+| SMTP Password  | Password          |
+| SMTP TLS       | Ja oder Nein      |
+| Sender         | E-Mail Adresse    |
+| Name           | Name              |
+| Timeout        | Wert in Sekunden  |
+| SMTP Debug     | Ja oder Nein      |
+| Subject prefix | String            |
+
+Zusätzlich gibt es einen Button, der die SMTP Verbindung testet.
 
 ### Proxy
 

--- a/docs/en/system-administration/admin-center.md
+++ b/docs/en/system-administration/admin-center.md
@@ -77,6 +77,23 @@ Setting can also be toggled via [Expert settings](#expert-settings-system-relate
 | ------------------------- | ------ |
 | Welcome message for login | String |
 
+### SMTP
+
+| Option         | Value            |
+| -------------- | ---------------- |
+| SMTP Host      | Hostname or URL  |
+| SMTP Port      | Port             |
+| SMTP Username  | Username         |
+| SMTP Password  | Password         |
+| SMTP TLS       | Yes or No        |
+| Sender         | E-Mail address   |
+| Name           | Name             |
+| Timeout        | Value in seconds |
+| SMTP Debug     | Yes or no        |
+| Subject prefix | String           |
+
+There is also a button that tests the SMTP connection.
+
 ### Proxy
 
 | Option          | Value              |

--- a/docs/en/system-administration/administration/import-and-interfaces/smtp.md
+++ b/docs/en/system-administration/administration/import-and-interfaces/smtp.md
@@ -2,16 +2,16 @@
 
 Here you can configure the mail server used by i-doit.
 
-| Option | Value |
-| - | - |
-| SMTP Host | Hostname or URL |
-| SMTP Port	| Port |
-| SMTP Username | Username |
-| SMTP Password	| Password |
-| SMTP TLS | Yes or No |
-| Sender | E-Mail address |
-| Name | Name |
-| Timeout | Value in seconds |
-| SMTP Debug | Yes or no |
-| Subject prefix | String |
-| Notification template for maintenance contract | HTMl |
+| Option                                         | Value            |
+| ---------------------------------------------- | ---------------- |
+| SMTP Host                                      | Hostname or URL  |
+| SMTP Port                                      | Port             |
+| SMTP Username                                  | Username         |
+| SMTP Password                                  | Password         |
+| SMTP TLS                                       | Yes or No        |
+| Sender                                         | E-Mail address   |
+| Name                                           | Name             |
+| Timeout                                        | Value in seconds |
+| SMTP Debug                                     | Yes or no        |
+| Subject prefix                                 | String           |
+| Notification template for maintenance contract | HTMl             |


### PR DESCRIPTION
Make smtp configuration in admin-center more user-friendly