### PR TITLE
Update RHEL Title to 9.5

### DIFF
--- a/docs/de/installation/manuelle-installation/red-hat-enterprise-linux/index.md
+++ b/docs/de/installation/manuelle-installation/red-hat-enterprise-linux/index.md
@@ -1,6 +1,6 @@
 ---
-title: Red Hat Enterprise Linux 9.4
-description: i-doit installation auf RHEL 9.4
+title: Red Hat Enterprise Linux 9.5
+description: i-doit installation auf RHEL 9.5
 icon: material/redhat
 status:
 lang: de

--- a/docs/en/installation/manual-installation/red-hat-enterprise-linux/index.md
+++ b/docs/en/installation/manual-installation/red-hat-enterprise-linux/index.md
@@ -1,6 +1,6 @@
 ---
-title: Red Hat Enterprise Linux 9.4
-description: i-doit installation auf RHEL 9.4
+title: Red Hat Enterprise Linux 9.5
+description: i-doit installation auf RHEL 9.5
 icon: material/redhat
 status:
 lang: en


### PR DESCRIPTION
The manual installation guides are written for RHEL `9.5`, but the document titles still said `9.4`.