### PR TITLE
Add warnings for MariaDB versions during SQL dump migration

### DIFF
--- a/docs/de/upgrades-und-umzuege/umzug-von-linux-zu-windows.md
+++ b/docs/de/upgrades-und-umzuege/umzug-von-linux-zu-windows.md
@@ -39,6 +39,19 @@ scp -r user@linuxsystem:/var/www/html/i-doit/i-doit.zip C:\
 
 ## Datenbank aus Linux exportieren
 
+??? warning "Bitte beachten Sie, dass bei einem SQL Dump unter Verwendung der folgenden MariaDB-Versionen zu einem Fehler beim importieren des Dumps unter Windows kommen wird:"
+    - 10.5.25
+    - 10.6.18
+    - 10.11.8
+    - 11.0.6
+    - 11.1.5
+    - 11.2.4
+    - 11.4.2
+
+    Die aufgelisteten Versionen setzen bei einem SQL Dump ein "Sandbox command" in die erste Zeile des Dumps.
+    Dadurch kann dieser Dump dann nur noch mit den gelisteten MariaDB Versionen importiert werden, da die mitgelieferte MariaDB Version vom Windows installer keine der gelisteten Versionen ist, wird man beim Import auf den Fehler **```ERROR at line 1: Unknown command '\-'```** stoßen.
+    Wir empfehlen daher für den Dump eine andere MariaDB Version zu nutzen, welche nicht oben aufgelistet ist!
+
 Als nächstes müssen wir die Datenbank exportieren und ebenfalls auf den Windows Server transferieren. Um die Datenbank erfolgreich zu exportieren müssen folgende Befehle ausgeführt werden:
 
 ```shell
@@ -87,6 +100,11 @@ Jetzt können wir die Datenbanken aus der alten Instanz einspielen:
 mysql -uroot -p idoit_data < C:\idoit_data.sql
 mysql -uroot -p idoit_system < C:\idoit_system.sql
 ```
+
+??? danger "Wenn der Fehler **```ERROR at line 1: Unknown command '\-'```** auftritt:"
+    Wenn der obige Fehler auftritt, haben Sie den SQL Dump mit einer MariaDB Version durchgeführt, welche ein "Sandbox Command" in die erste Zeile des Dumps schreibt.
+    Diese Zeile kann nur von bestimmten MariaDB Versionen interpretiert werden, was auf die mitgelieferte MariaDB Version des Windows installers nicht zutrifft (Siehe [Liste](#datenbank-aus-linux-exportieren)).
+    Die Fehler-verursachende Zeile ist ```/*!999999\- enable the sandbox mode */```, diese muss entweder manuell aus dem Dump entfernt werden oder Sie wechseln auf eine andere MariaDB Version und führen den Dump erneut durch.
 
 Zusätzlich berechtigen wir den idoit User für die neuen Datenbanken:
 

--- a/docs/en/upgrades-and-migrations/migration-from-linux-to-windows.md
+++ b/docs/en/upgrades-and-migrations/migration-from-linux-to-windows.md
@@ -39,6 +39,19 @@ scp -r user@linuxsystem:/var/www/html/i-doit/i-doit.zip C:\
 
 ## Export the Database from Linux
 
+??? warning "Please note that if you are using the following MariaDB versions to dump the database, it will result in an error when importing the dump under Windows:"
+    - 10.5.25
+    - 10.6.18
+    - 10.11.8
+    - 11.0.6
+    - 11.1.5
+    - 11.2.4
+    - 11.4.2
+
+    The listed versions write a "Sandbox command" in the first line of an SQL dump.
+    This means that this dump can only be imported with the listed MariaDB versions, as the MariaDB version installed with the Windows installer is not one of the listed versions, you will encounter the error **```ERROR at line 1: Unknown command '\-'```** when importing.
+    We therefore recommend using a different MariaDB version for the dump, which is not listed above!
+
 Next, we need to export the database and transfer it to the Windows server as well. To export the database successfully, the following commands must be executed:
 
 ```shell
@@ -87,6 +100,11 @@ Now we can import the databases from the old instance:
 mysql -uroot -p idoit_data < C:\idoit_data.sql
 mysql -uroot -p idoit_system < C:\idoit_system.sql
 ```
+
+??? danger "If the error **````ERROR at line 1: Unknown command '\-'```** occurs:"
+    If the above error occurs, you have dumped the database with a MariaDB version that writes a "sandbox command" in the first line of the dump.
+    This line can only be interpreted by certain MariaDB versions, which does not apply to the MariaDB version installed with the Windows installer (see [list](#export-the-database-from-linux)).
+    The line causing the error is ```/*!999999\- enable the sandbox mode */````, this line must either be removed manually from the dump or you can switch to a different MariaDB version and perform the dump again.
 
 We also authorize the idoit user for the new databases:
 


### PR DESCRIPTION
Include warnings about specific MariaDB versions that cause import errors on Windows when performing SQL dumps. Recommend using alternative versions to avoid issues.