### PR TITLE
Update i-doit Admin-Center credentials in Windows installation guide

### DIFF
--- a/docs/de/installation/manuelle-installation/microsoft-windows-server/index.md
+++ b/docs/de/installation/manuelle-installation/microsoft-windows-server/index.md
@@ -61,7 +61,7 @@ Hier finden Sie die Login Daten für den i-doit Windows installer:
 | ------------------------- | --------------------- | -------- |
 | MariaDB root              | root                  | idoit    |
 | MariaDB i-doit            | idoit                 | idoit    |
-| i-doit Admin-Center       | -                     | admin    |
+| i-doit Admin-Center       | admin                 | admin    |
 | Installations Verzeichnis | C:\ProgramData\i-doit | -        |
 
 Die i-doit Login Daten finden Sie [hier](../../../grundlagen/erstanmeldung.md).


### PR DESCRIPTION
Revise the credentials for the i-doit Admin-Center in the Windows installation documentation to reflect the correct username.