### PR TITLE
Update virtual host instructions for i-doit setup in RHEL documentation

### DIFF
--- a/docs/de/installation/manuelle-installation/red-hat-enterprise-linux/index.md
+++ b/docs/de/installation/manuelle-installation/red-hat-enterprise-linux/index.md
@@ -162,10 +162,9 @@ Die Welcome Page wird, durch umbenennen, deaktiviert:
 sudo mv /etc/httpd/conf.d/welcome.conf{,.bak}
 ```
 
-Der Default-VirtualHost wird deaktiviert und ein neuer angelegt:
+Nun wird ein neuer Virtual Host für i-doit angelegt:
 
 ```sh
-sudo mv /etc/php-fpm.d/www.conf{,.bak}
 sudo nano /etc/httpd/conf.d/i-doit.conf
 ```
 

--- a/docs/en/installation/manual-installation/red-hat-enterprise-linux/index.md
+++ b/docs/en/installation/manual-installation/red-hat-enterprise-linux/index.md
@@ -158,10 +158,9 @@ The Welcome Page is deactivated by renaming it:
 sudo mv /etc/httpd/conf.d/welcome.conf{,.bak}
 ```
 
-The default VirtualHost is deactivated and a new one is created:
+Now a new virtual host is created for i-doit:
 
 ```sh
-sudo mv /etc/php-fpm.d/www.conf{,.bak}
 sudo nano /etc/httpd/conf.d/i-doit.conf
 ```
 


### PR DESCRIPTION
Revise the instructions to clarify the creation of a new virtual host for i-doit, enhancing the setup process in the documentation.