### PR TITLE
Update LDAP documentation with required permissions and formatting improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -231,6 +231,7 @@
         "Weblicense",
         "Webtatic",
         "wwwrun",
+        "xampp",
         "XAMPP",
         "xdebug",
         "xmlwriter",
@@ -239,7 +240,17 @@
         "zeitbasierte",
         "zeitbasierten",
         "zeitbasierter",
-        "zypper"
+        "zypper",
+        "setsebool",
+        "getsebool",
+        "ssl",
+        "Attributeerweitertung",
+        "samaccountname",
+        "isset"
     ],
-    "editor.renderWhitespace": "trailing"
+    "editor.renderWhitespace": "trailing",
+    "cSpell.ignoreRegExpList": [
+        "/^(\\s*`{3,}).*`[\\s\\S]*?^\\1 /gmx",
+        "`[^`]*`"
+    ]
 }

--- a/docs/de/benutzerauthentifizierung-und-verwaltung/ldap-verzeichnis/index.md
+++ b/docs/de/benutzerauthentifizierung-und-verwaltung/ldap-verzeichnis/index.md
@@ -13,7 +13,7 @@ Für die Authentifizierung/Autorisierung und Synchronisierung von Daten aus eine
 !!! info ""
     Ein Praxisbeispiel finden Sie auf unserem [Blog](https://www.i-doit.com/blog/ldap-integration-mit-i-doit/)
 
-**Voraussetzungen**
+## Voraussetzungen
 
 i-doit unterstützt folgende Verzeichnisdienste:
 
@@ -23,10 +23,22 @@ i-doit unterstützt folgende Verzeichnisdienste:
 
 Die [PHP-Extension php_ldap](http://de.php.net/manual/de/ldap.setup.php) für die Kommunikation mit einem Active Directory (AD) bzw. LDAP-Verzeichnis muss installiert und aktiviert werden. Wer den Installationsanweisungen gefolgt ist, hat die Extension bereits auf dem System.
 
-Nicht vergessen, LDAP zu erlauben, wenn SELinux verwendet wird. Dazu `setsebool -P httpd_can_connect_ldap on` verwenden. Das -P steht für Permanent<br>
-Überprüfen Sie dies mit `getsebool -a | grep httpd`
+Nicht vergessen, LDAP zu erlauben, wenn SELinux verwendet wird. Dazu `setsebool -P httpd_can_connect_ldap on` verwenden. Das -P steht für Permanent. Überprüfen Sie dies mit `getsebool -a | grep httpd`
 
-## Nachträgliche Installation unter Debian GNU/Linux
+### Benötigte Rechte für den LDAP-Sync
+
+Ein Benutzer für den `ldap-sync` Befehl benötigt folgende Mindestberechtigungen:
+
+**1. Verwaltung (Befehl ausführen)**
+
+- Bedingung **Commands** und `Alle` Rechte für den Parameter `SyncCommand`.
+
+**2. CMDB (Objekte & Gruppen bearbeiten)**
+
+- Bedingung **Kategorie in Objekttyp "Personen"** und `Alle` Rechte für die Kategorie `Personen - Personengruppenmitgliedschaft`.
+
+
+### Nachträgliche Installation unter Debian GNU/Linux
 
 ```shell
 sudo apt install php-ldap
@@ -66,7 +78,7 @@ Unter **Verwaltung → Import und Schnittstellen → LDAP → Server** können e
 | **Aktiv**                                           | Soll der Server beim Login mit abgefragt werden?                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | **Directory**                                       | **Pflichtfeld**: Welche Art Directory wird abgefragt?                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **LDAP-Version**                                    | In welcher Version ist das Directory vorhanden? (Standard: 3)                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| **Enable LDAP Paging**                              | Soll die maximale Anzahl der Suchergebnisse aktiviert/überschrieben werden?  <br>Dann werden die Ergebnisse "päckchenweise" übermittelt.<br><br>_In einem LDAP-Suchvorgang muss stets damit gerechnet werden, dass der LDAP-Server eine Obergrenze der zurückgelieferten Ergebnisse pro Suchanfrage hat. Man sucht z.B. nach allen User-Objekten in einer gesamten OU-Struktur, bekommt aber nur 500 User als Ergebnis zurück, obwohl sich weit über 2000 User auf dem Server befinden müssen._ |
+| **Enable LDAP Paging**                              | Soll die maximale Anzahl der Suchergebnisse aktiviert/überschrieben werden?  <br>Dann werden die Ergebnisse Paket für Paket übermittelt.<br><br>_In einem LDAP-Suchvorgang muss stets damit gerechnet werden, dass der LDAP-Server eine Obergrenze der zurückgelieferten Ergebnisse pro Suchanfrage hat. Man sucht z.B. nach allen User-Objekten in einer gesamten OU-Struktur, bekommt aber nur 500 User als Ergebnis zurück, obwohl sich weit über 2000 User auf dem Server befinden müssen._ |
 | **LDAP Page Limit**                                 | Wie viele Ergebnisse sollen pro "Päckchen" zurückgeliefert werden?                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | **IP / Hostname**                                   | **Pflichtfeld**: Die IP oder der Hostname des Servers                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **Port**                                            | **Pflichtfeld**: Über welchen Port wird die Abfrage durchgeführt? (Standard: 389)                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -146,10 +158,10 @@ Ein Beispiel dazu ist [hier](../../automatisierung-und-integration/cli/configura
 | **defaultCompany**            | Hierdurch werden durch die LDAP-Synchronisation hinzugefügte Benutzer automatisch der konfigurierten<br><br>Organisation zugewiesen. (Standard: leer)<br><br>Bsp. <br><br>defaultCompany='i-doit'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | **deletedUsersBehaviour**     | Kann auf **archive**, **delete** und **disable_login** gesetzt werden um Benutzer auf [archiviert bzw. gelöscht](../../grundlagen/lebens-und-dokumentationszyklus.md) zu setzen, die nicht mehr über die Synchronisation gefunden werden. Ein archivierter/gelöschter Benutzer kann sich nicht mehr in i-doit anmelden.<br><br>deletedUserBehavior=archive, setzt den Status des Benutzers auf archiviert  <br>deletedUserBehavior=delete, setzt den Status des Benutzers auf gelöscht  <br>deletedUserBehavior=disable\_login, setzt den Status des Benutzers auf normal und Deaktiviere Login auf Ja<br><br>(Standard: **archive)**<br><br>Bsp.<br><br>deletedUsersBehaviour=archive |
 | **disabledUsersBehaviour**    | Kann auf **archive**, **delete** und **disable_login** gesetzt werden um Benutzer auf [archiviert bzw. gelöscht](../../grundlagen/lebens-und-dokumentationszyklus.md) zu setzen, die nicht mehr über die Synchronisation gefunden werden. Ein archivierter/gelöschter Benutzer kann sich nicht mehr in i-doit anmelden.<br><br>Oder man deaktiviert nur den Login für die User.<br><br>Bsp.<br><br>disabledUsersBehaviour=archive                                                                                                                                                                                                                                                      |
-| **rooms**                     | Wie in dem Beispiel kann hier eine Zuweisung von Benutzer zu einem Raum vordefiniert werden, die bei der Synchronisation vorgenommen wird. Die Zuweisung wird über die Kontaktzuweisung ohne eine Rolle realisiert.<br><br>Bsp. <br><br>rooms["Raum B"] = ["Person A", "Person C", "Person D"]                                                                                                                                                                                                                                                                                                                                                                                         |
-| **attributes**                | Hiermit werden die jeweiligen Felder aus dem Directory mit Attributen in i-doit verknüpft. Diese ergänzen die zugewiesenen Attribute aus dem oberen Teil der Anleitung.<br><br>Bsp.<br><br>attributes[department]=department                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **rooms**                     | Wie in dem Beispiel kann hier eine Zuweisung von Benutzer zu einem Raum vordefiniert werden, die bei der Synchronisation vorgenommen wird. Die Zuweisung wird über die Kontaktzuweisung ohne eine Rolle realisiert.<br><br>Bsp. <br><br>rooms\["Raum B"] = \["Person A", "Person C", "Person D"]                                                                                                                                                                                                                                                                                                                                                                                       |
+| **attributes**                | Hiermit werden die jeweiligen Felder aus dem Directory mit Attributen in i-doit verknüpft. Diese ergänzen die zugewiesenen Attribute aus dem oberen Teil der Anleitung.<br><br>Bsp.<br><br>attributes\[department]=department                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | **autoReactivateUsers**       | Ist nur für Novel Directory Services (NDS) und OpenLDAP relevant. Hierdurch werden bei der Synchronisation erst mal alle Benutzer wieder aktiviert und nach dem regulären Prinzip wieder deaktiviert, falls zutreffend.<br><br>Bsp.<br><br>autoReactivateUsers=false                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| **ignoreUsersWithAttributes** | Diese Funktion hilft, eine Synchronisation unerwünschter Verzeichnisobjekte zu verhindern.<br><br>Der Benutzer wird nicht synchronisiert, wenn die ignoreFunctionfür alle ausgewählten Attribute fehlschlägt.<br><br>Bsp.<br><br>ignoreUsersWithAttributes\[\] = "samaccountname"                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **ignoreUsersWithAttributes** | Diese Funktion hilft, eine Synchronisation unerwünschter Verzeichnisobjekte zu verhindern.<br><br>Der Benutzer wird nicht synchronisiert, wenn die ignoreFunction für alle ausgewählten Attribute fehlschlägt.<br><br>Bsp.<br><br>ignoreUsersWithAttributes\[\] = "samaccountname"                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **ignoreFunction**            | Dies kann ein beliebiger Funktionsname sein, der über call\_user\_func oder die definierten Funktionen aufrufbar ist.<br><br>Definierte Funktionen:<br><br>empty  <br>!empty  <br>isset  <br>!isset<br><br>Bsp,<br><br>ignoreFunction\=empty                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **syncEmptyAttributes**       | Wurden Werte aus Feldern im AD gelöscht/geleert werden diese in i-doit übernommen<br><br>syncEmptyAttributes=true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
@@ -157,7 +169,7 @@ Ein Beispiel dazu ist [hier](../../automatisierung-und-integration/cli/configura
 
 Die automatische Zuweisung sorgt dafür, dass nach dem Login automatisch die für die Personengruppe festgelegten Berechtigungen zugewiesen werden. Damit die Zuweisung erfolgen kann, muss in den **Stammdaten** einer **Personengruppe** das Attribut **LDAP-Gruppe (Mapping)** mit einer validen Gruppe aus LDAP/AD gefüllt werden. Loggt sich ein Benutzer ein oder wird die Synchronisation ausgeführt, werden automatisch auch die dem Benutzerobjekt im Directory zugewiesenen Gruppen abgefragt und mit dem Attribut **LDAP-Gruppe (Mapping)** der Personengruppen verglichen. Gibt es eine Übereinstimmung wird die Gruppe zugewiesen und die weiteren Gruppen abgefragt.
 
-[![ldap-autozuweis](../../assets/images/de/automatisierung-und-integration/ldap/1-ldap.png)](../../assets/images/de/automatisierung-und-integration/ldap/1-ldap.png)
+[![ldap-autozuweisung](../../assets/images/de/automatisierung-und-integration/ldap/1-ldap.png)](../../assets/images/de/automatisierung-und-integration/ldap/1-ldap.png)
 
 !!! info "memberOf bei OpenLDAP"
     Die automatische Zuweisung beruht auf der LDAP-Abfrage, in welchen Gruppen ein Benutzer ist. Hierbei spielt das Attribut memberOf eine wichtige Rolle. Dieses Attribut muss als Overlay verfügbar sein, was in vielen Standard-Installationen von OpenLDAP nicht der Fall ist. Gute Artikel für die nötige Konfiguration befinden sich [hier](http://www.adimian.com/blog/2014/10/how-to-enable-memberof-using-openldap/) und [hier](https://technicalnotes.wordpress.com/2014/04/19/openldap-setup-with-memberof-overlay/).
@@ -184,22 +196,3 @@ Der ldap-sync lässt sich nur über die Console des Servers ausführen. Um die C
 ```shell
 sudo -u www-data php console.php ldap-sync --user admin --password admin --tenantId 1 --verbose --ldapServerId 1
 ```
-
-## Benötigte Rechte für den LDAP-Sync
-
-Ein Benutzer für den `ldap-sync` Befehl benötigt folgende Mindestberechtigungen:
-
-**1. Verwaltung (Befehl ausführen)**
-* Bedingung **Commands** und `Alle` Rechte für den Parameter `SyncCommand`.
-
-**2. CMDB (Objekte & Gruppen bearbeiten)**
-* Bedingung **Kategorie in Objekttyp "Personen"**: Rechte auf die Kategorien:
-    * Personen
-    * Personen - Stammdaten
-    * Personen - Login
-    * Personen - Gruppenmitgliedschaften
-
-* **Objekttyp Kategorie in Objekttyp "Personengruppen"**: Rechte auf die Kategorien:
-    * Personengruppen
-    * Personengruppen - Stammdaten
-    * Personengruppen - Gruppenmitgliedschaften

--- a/docs/en/user-authentication-and-management/ldap-directory/index.md
+++ b/docs/en/user-authentication-and-management/ldap-directory/index.md
@@ -15,6 +15,19 @@ The [PHP-Extension php_ldap](http://de.php.net/manual/en/ldap.setup.php) has to 
 Don't forget to allow LDAP connection if you are using **SELinux** with `setsebool -P httpd_can_connect_ldap on`. The -P is for Permanent
 Verify it via `getsebool -a | grep httpd`
 
+### Required Permissions for the LDAP Sync
+
+A user for the `ldap-sync` command requires the following minimum permissions:
+
+**1. Administration (Execute Command)**
+
+- Condition **Commands** and `All` permissions for the `SyncCommand` parameter.
+
+**2. CMDB (Edit Objects & Groups)**
+
+- Condition **Category in Object Type "Persons"** and `All` permissions for the `Persons - Person group memberships` category.
+
+
 ### Subsequent Installation under [Debian GNU/Linux](../../installation/manual-installation/debian/index.md)
 
 ```shell
@@ -38,7 +51,7 @@ the ";" is deleted, resulting in
 extension=php_ldap.dll
 ```
 
-Sometimes it may also be necessary to copy the files ssleay32.dll and libeay32.dll (in most cases they are located at `C:\xampp\apache\bin\`, however, this varies from version to version) to the php\ folder. The Apache web server has to be restarted afterwards.
+Sometimes it may also be necessary to copy the files `ssleay32.dll` and `libeay32.dll` (in most cases they are located at `C:\xampp\apache\bin\`, however, this varies from version to version) to the php\ folder. The Apache web server has to be restarted afterwards.
 
 ## Configuration
 
@@ -134,8 +147,8 @@ So that this file is considered e.g. with the ldap-sync Command, this must be in
 | **defaultCompany**            | Through this the users added by the LDAP synchronization are assigned automatically to the configured organization. (Default: **empty**)<br><br>e.g .<br><br>defaultCompany='i-doit'                                                                                                                                                                                                                                             |
 | **deletedUsersBehaviour**     | Can be set to **archive**, **delete** or **disable_login** to set users to the status [archived or deleted](../../basics/life-and-documentation-cycle.md) when they cannot be found anymore via the synchronization. A user that is archived or deleted cannot log in to _i-doit_ anymore!<br><br>Or you just deactivate the login for the users.<br><br>(Default: **archive**)<br><br>e.g.<br><br>deletedUsersBehaviour=archive |
 | **disabledUsersBehaviour**    | Can be set to **archive**, **delete** or **disable_login** to set users to the status [archived or deleted](../../basics/life-and-documentation-cycle.md) when they cannot be found anymore via the synchronization. A user that is archived or deleted cannot log in to _i-doit_ anymore!<br><br>Or you just deactivate the login for the users.<br><br>e.g.<br><br>disabledUsersBehaviour=archive                              |
-| **rooms**                     | As seen in the example, an assignment of an user to a **room** can be predefined here. The assignment is carried out via the contact assignment without a role.<br><br>e.g. <br><br>rooms["Raum B"] = ["Person A", "Person C", "Person D"]                                                                                                                                                                                       |
-| **attributes**                | The respective fields from the directory are linked with attributes in _i-doit_ using the "Attributes". These complement the assigned attributes described in the above mentioned part of the guide.<br><br>e.g.<br><br>attributes[department]=department                                                                                                                                                                        |
+| **rooms**                     | As seen in the example, an assignment of an user to a **room** can be predefined here. The assignment is carried out via the contact assignment without a role.<br><br>e.g. <br><br>rooms\["Raum B"] = \["Person A", "Person C", "Person D"]                                                                                                                                                                                     |
+| **attributes**                | The respective fields from the directory are linked with attributes in _i-doit_ using the "Attributes". These complement the assigned attributes described in the above mentioned part of the guide.<br><br>e.g.<br><br>attributes\[department]=department                                                                                                                                                                       |
 | **autoReactivateUsers**       | This is only relevant for Novel Directory Services (NDS) and OpenLDAP. During synchronization all users are activated again with this and deactivated according to the common principle, if applicable.<br><br>e.g.<br><br>autoReactivateUsers=false                                                                                                                                                                             |
 | **ignoreUsersWithAttributes** | This function helps to prevent synchronization of unwanted directory objects.<br><br>The user will not be synchronized if the **ignoreFunction** fails for all selected attributes.<br><br>e.g.<br><br>ignoreUsersWithAttributes\[\]\="samaccountname"                                                                                                                                                                           |
 | **ignoreFunction**            | This can be any function name which can be called through call\_user\_func or the defined functions.<br><br>Defined functions:<br><br>empty  <br>!empty  <br>isset  <br>!isset<br><br>e.g,<br><br>ignoreFunction\=empty                                                                                                                                                                                                          |
@@ -152,7 +165,7 @@ The automated assignment makes sure that the specified permissions of the person
 [![Automated Assignment of Persons to Person Groups](../../assets/images/en/automation-and-integration/ldap/1-ldap.png)](../../assets/images/en/automation-and-integration/ldap/1-ldap.png)
 
 !!! info "memberOf with OpenLDAP"
-    The automatical assignment is based on LDAP querying in which groups there is a user. The memberOf attribute plays an important role in this connection. This attribute has to be available as an overlay. However, in many default installations of OpenLDAP this is not the case. Useful information about the required configurations can be found in [this](http://www.adimian.com/blog/2014/10/how-to-enable-memberof-using-openldap/) and [this article](https://technicalnotes.wordpress.com/2014/04/19/openldap-setup-with-memberof-overlay/).
+    The automatic assignment is based on LDAP querying in which groups there is a user. The memberOf attribute plays an important role in this connection. This attribute has to be available as an overlay. However, in many default installations of OpenLDAP this is not the case. Useful information about the required configurations can be found in [this](http://www.adimian.com/blog/2014/10/how-to-enable-memberof-using-openldap/) and [this article](https://technicalnotes.wordpress.com/2014/04/19/openldap-setup-with-memberof-overlay/).
 
 ### Synchronize persons and groups of persons
 
@@ -174,22 +187,3 @@ The ldap-sync can only be executed via the console of the server. To be able to 
 ```shell
 sudo -u www-data php console.php ldap-sync --user admin --password admin --tenantId 1 --verbose --ldapServerId 1
 ```
-
-## Required Permissions for the LDAP Sync
-
-A user for the `ldap-sync` command requires the following minimum permissions:
-
-**1. Administration (Execute Command)**
-* Condition **Commands**: `All` permissions for the `SyncCommand` parameter.
-
-**2. CMDB (Edit Objects & Groups)**
-* Condition **Category in Object Type "Persons"**: Permissions for the categories:
-    * Persons
-    * Person - Master Data
-    * Person - Login
-    * Person - Group Memberships
-
-* Condition **Category in Object Type "Person groups"**: Permissions for the categories:
-    * Person groups
-    * Person groups - Master Data
-    * Person groups - Memberships


### PR DESCRIPTION
Enhance the LDAP documentation by adding required permissions for the `ldap-sync` command and improving formatting for clarity.