### PR TITLE
Standardize naming for SHD Connect adapters

### DIFF
--- a/docs/de/i-doit-add-ons/sm-view-connect/baramundi-adapter.md
+++ b/docs/de/i-doit-add-ons/sm-view-connect/baramundi-adapter.md
@@ -1,6 +1,6 @@
 ---
-title: SHD SM-VIEW Connect - Baramundi-Adapter
-description: SHD SM-VIEW Connect - Baramundi-Adapter
+title: SHD Connect - Baramundi-Adapter
+description: SHD Connect - Baramundi-Adapter
 icon:
 status:
 lang: de

--- a/docs/de/i-doit-add-ons/sm-view-connect/index.md
+++ b/docs/de/i-doit-add-ons/sm-view-connect/index.md
@@ -1,6 +1,6 @@
 ---
-title: SHD SM-VIEW Connect
-description: SHD SM-VIEW Connect
+title: SHD Connect
+description: SHD Connect
 icon:
 status:
 lang: de
@@ -10,9 +10,9 @@ Dieses Modul benötigt den [**SM-VIEW Client**](https://smdocu.atlassian.net/wik
 
 ## Installation
 
-Die aktuelle Version des SM-VIEW Connect Add-On kann unter folgendem Link heruntergeladen werden: <https://www.sm-view.de/>
+Die aktuelle Version des SHD Connect Add-On kann unter folgendem Link heruntergeladen werden: <https://www.sm-view.de/>
 
-Eine Auflistung der verschiedenen Versionen inklusive deren Changelog kann unter folgendem Link eingesehen werden: [SM-VIEW Connect Modul](https://smdocu.atlassian.net/wiki/x/KwCcgw)
+Eine Auflistung der verschiedenen Versionen inklusive deren Changelog kann unter folgendem Link eingesehen werden: [SHD Connect Modul](https://smdocu.atlassian.net/wiki/x/KwCcgw)
 
 Nachdem Sie das Add-On heruntergeladen haben können Sie dies bequem über die Administrationsoberfläche von i-doit hochladen und installieren.
 
@@ -20,7 +20,7 @@ Nachdem Sie das Add-On heruntergeladen haben können Sie dies bequem über die A
 
 ## Konfiguration
 
-Zur Verwendung des Add-Ons muss eine entsprechende Berechtigung erteilt werden. Erst dann ist SM-VIEW Connect im Add-On-Menü von i-doit sichtbar:
+Zur Verwendung des Add-Ons muss eine entsprechende Berechtigung erteilt werden. Erst dann ist SHD Connect im Add-On-Menü von i-doit sichtbar:
 
 [![grafik-20230926-071455.png](../../assets/images/de/i-doit-add-ons/sm-view-connect/grafik-20230926-071455.png)](../..//assets/images/de/i-doit-add-ons/sm-view-connect/grafik-20230926-071455.png)
 
@@ -44,10 +44,10 @@ Aktuell stehen folgende Adapter zur Verfügung
 
 Zur Nutzung der Adapter stehen Ihnen folgende Seiten mit weiteren Informationen zur Verfügung:
 
-[SM-VIEW Connect - Grundlagen](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296709121/SM-VIEW+Connect+-+Grundlagen)<br>
-[SM-VIEW Connect - AD/LDAP-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308636717)<br>
-[SM-VIEW Connect - Aeneis-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308538370/SM-VIEW+Connect+-+Aeneis-Adapter)<br>
-[SM-VIEW Connect - Baramundi-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296479745/SM-VIEW+Connect+-+Baramundi-Adapter)<br>
-[SM-VIEW Connect - Macmon-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2337341442/SM-VIEW+Connect+-+Macmon-Adapter)<br>
-[SM-VIEW Connect - Telekom-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296709154/SM-VIEW+Connect+-+Telekom-Adapter)<br>
-[SM-VIEW Connect - vSphere-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308636674/SM-VIEW+Connect+-+vSphere-Adapter)
+[SHD Connect - Grundlagen](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296709121/SM-VIEW+Connect+-+Grundlagen)<br>
+[SHD Connect - AD/LDAP-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308636717)<br>
+[SHD Connect - Aeneis-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308538370/SM-VIEW+Connect+-+Aeneis-Adapter)<br>
+[SHD Connect - Baramundi-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296479745/SM-VIEW+Connect+-+Baramundi-Adapter)<br>
+[SHD Connect - Macmon-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2337341442/SM-VIEW+Connect+-+Macmon-Adapter)<br>
+[SHD Connect - Telekom-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296709154/SM-VIEW+Connect+-+Telekom-Adapter)<br>
+[SHD Connect - vSphere-Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308636674/SM-VIEW+Connect+-+vSphere-Adapter)

--- a/docs/de/i-doit-add-ons/sm-view-connect/telekom-adapter.md
+++ b/docs/de/i-doit-add-ons/sm-view-connect/telekom-adapter.md
@@ -1,6 +1,6 @@
 ---
-title: SHD SM-VIEW Connect - Telekom-Adapter
-description: SHD SM-VIEW Connect - Telekom-Adapter
+title: SHD Connect - Telekom-Adapter
+description: SHD Connect - Telekom-Adapter
 icon:
 status:
 lang: de

--- a/docs/en/i-doit-add-ons/sm-view-connect/baramundi-adapter.md
+++ b/docs/en/i-doit-add-ons/sm-view-connect/baramundi-adapter.md
@@ -1,6 +1,6 @@
 ---
-title: SHD SM-VIEW Connect - Baramundi-Adapter
-description: SHD SM-VIEW Connect - Baramundi-Adapter
+title: SHD Connect - Baramundi-Adapter
+description: SHD Connect - Baramundi-Adapter
 icon:
 status:
 lang: en

--- a/docs/en/i-doit-add-ons/sm-view-connect/index.md
+++ b/docs/en/i-doit-add-ons/sm-view-connect/index.md
@@ -1,6 +1,6 @@
 ---
-title: SHD SM-VIEW Connect
-description: SHD SM-VIEW Connect
+title: SHD Connect
+description: SHD Connect
 icon:
 status:
 lang: en
@@ -10,10 +10,46 @@ This module requires the [**SM-VIEW Client**](https://smdocu.atlassian.net/wiki/
 
 ## Installation
 
-The current version of the SM-VIEW Connect add-on can be downloaded from the following link: <https://www.sm-view.de/>
+The current version of the SHD Connect add-on can be downloaded from the following link: <https://www.sm-view.de/>
 
-A list of the different versions including their changelog can be viewed at the following link: [SM-VIEW Connect Modul](https://smdocu.atlassian.net/wiki/x/KwCcgw)
+A list of the different versions including their changelog can be viewed at the following link: [SHD Connect Modul](https://smdocu.atlassian.net/wiki/x/KwCcgw)
 
 Once you have downloaded the add-on, you can easily upload and install it via the i-doit administration interface.
 
 [To the documentation of the add-on](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2185429011/Modul+Connect){ .md-button .md-button--primary }
+
+
+## Configuration
+
+To use the add-on, the appropriate permission must be granted. Only then will SHD Connect be visible in the add-on menu of i-doit:
+
+[![grafik-20230926-071455.png](../../assets/images/de/i-doit-add-ons/sm-view-connect/grafik-20230926-071455.png)](../..//assets/images/de/i-doit-add-ons/sm-view-connect/grafik-20230926-071455.png)
+
+
+To use one or more adapters, an appropriate license is required. This license is usually provided to you by synetics as part of your license key. The prerequisite for this is the purchase of the respective adapter in the synetics marketplace.
+
+Another option is to provide the license directly from SHD. The corresponding license file can be uploaded in the management area:
+
+[![grafik-20230926-072148.png](../../assets/images/de/i-doit-add-ons/sm-view-connect/grafik-20230926-072148.png)](../..//assets/images/de/i-doit-add-ons/sm-view-connect/grafik-20230926-072148.png)
+
+Currently, the following adapters are available
+
+-   LDAP (User and Clients)
+-   vSphere
+-   Baramundi
+-   Telekom Contracts
+-   Aeneis
+-   macmon / Cisco as CSV import
+-   Azure (still in development)
+
+## Using the Adapters
+
+For using the adapters, the following pages with more information are available:
+
+[SHD Connect - Basics](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296709121/SM-VIEW+Connect+-+Grundlagen)<br>
+[SHD Connect - AD/LDAP Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308636717)<br>
+[SHD Connect - Aeneis Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308538370/SM-VIEW+Connect+-+Aeneis-Adapter)<br>
+[SHD Connect - Baramundi Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296479745/SM-VIEW+Connect+-+Baramundi-Adapter)<br>
+[SHD Connect - Macmon Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2337341442/SM-VIEW+Connect+-+Macmon-Adapter)<br>
+[SHD Connect - Telekom Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2296709154/SM-VIEW+Connect+-+Telekom-Adapter)<br>
+[SHD Connect - vSphere Adapter](https://smdocu.atlassian.net/wiki/spaces/SKB/pages/2308636674/SM-VIEW+Connect+-+vSphere-Adapter)

--- a/docs/en/i-doit-add-ons/sm-view-connect/telekom-adapter.md
+++ b/docs/en/i-doit-add-ons/sm-view-connect/telekom-adapter.md
@@ -1,6 +1,6 @@
 ---
-title: SHD SM-VIEW Connect - Telekom-Adapter
-description: SHD SM-VIEW Connect - Telekom-Adapter
+title: SHD Connect - Telekom-Adapter
+description: SHD Connect - Telekom-Adapter
 icon:
 status:
 lang: en


### PR DESCRIPTION
Update titles and descriptions to unify the naming convention for SHD Connect adapters across multiple files. This change enhances consistency and clarity in the documentation.