### PR TITLE
Update logbook command to use new syntax

### DIFF
--- a/docs/de/administration/verwaltung/logbuch/index.md
+++ b/docs/de/administration/verwaltung/logbuch/index.md
@@ -10,7 +10,7 @@ Hier wird festgelegt für welchen Zeitraum Einträge im Logbuch vorgehalten werd
 
 [![Archivieren](../../../assets/images/de/administration/verwaltung/logbuch/2-l.png)](../../../assets/images/de/administration/verwaltung/logbuch/2-l.png)
 
-Damit das das Logbuch archiviert wird, muss der [logbook-archive](../../../automatisierung-und-integration/cli/index.md) Befehl ausgeführt werden.
+Damit das das Logbuch archiviert wird, muss der [logbook:archive](../../../automatisierung-und-integration/cli/index.md) Befehl ausgeführt werden.
 
 ## Listenansicht Logbuch
 

--- a/docs/de/automatisierung-und-integration/automatisierung-und-cronjobs.md
+++ b/docs/de/automatisierung-und-integration/automatisierung-und-cronjobs.md
@@ -28,8 +28,8 @@ set IDOIT_PASSWORD="admin"
 set TENANT_ID="1"
 
 :: Auszuführende Befehle
-:: Logbook-Archive: Archiviert die Logbucheinträge mit einem definierten Alter, gemäß den Einstellungen auf der i-doit Oberfläche.
-C:\ProgramData\i-doit\php\php.exe C:\ProgramData\i-doit\apache-2.4\htdocs\console.php logbook-archive --user %IDOIT_USERNAME% --password %IDOIT_PASSWORD% --tenantId %TENANT_ID%
+:: Logbook:Archive: Archiviert die Logbucheinträge mit einem definierten Alter, gemäß den Einstellungen auf der i-doit Oberfläche.
+C:\ProgramData\i-doit\php\php.exe C:\ProgramData\i-doit\apache-2.4\htdocs\console.php logbook:archive --user %IDOIT_USERNAME% --password %IDOIT_PASSWORD% --tenantId %TENANT_ID%
 
 :: Search-Index: Erneuert den Suchindex, indem dieser gelöscht und neu geschrieben wird.
 C:\ProgramData\i-doit\php\php.exe C:\ProgramData\i-doit\apache-2.4\htdocs\console.php search-index --user %IDOIT_USERNAME% --password %IDOIT_PASSWORD% --tenantId %TENANT_ID%

--- a/docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md
+++ b/docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md
@@ -48,7 +48,7 @@ lang: de
 | [license-list](#license-list)                                             | Listet alle Lizenzen mit allen Informationen auf (ID; Produkt; Typ; Startdatum; Enddatum; lizenzierte Objekte; lizenzierte Mandanten; Umgebung)                            |
 | [license-remove](#license-remove)                                         | Entfernt Lizenzen von i-doit                                                                                                                                               |
 | [list](#list)                                                             | Listet alle console Kommandos auf                                                                                                                                          |
-| [logbook-archive](#logbook-archive)                                       | Logbuch-Einträge archivieren                                                                                                                                               |
+| [logbook:archive](#logbookarchive)                                        | Logbuch-Einträge archivieren                                                                                                                                               |
 | [migrate-uploaded-files](#migrate-uploaded-files)                         | Migriert hochgeladene Dateien von i-doit <v1.13 zu v.1.14>                                                                                                                 |
 | [notifications-list](#notifications-list)                                 | Listet alle [Benachrichtigungen](../../auswertungen/benachrichtigungen.md) auf                                                                                             |
 | [notifications-send](#notifications-send)                                 | Benachrichtigungen per E-Mail versenden (Benachrichtigungen werden in der GUI konfiguriert)                                                                                |
@@ -853,7 +853,7 @@ Löscht eine Lizenz aus i-doit
 sudo -u www-data php console.php license-remove --user admin --password admin --license LicenseID
 ```
 
-### logbook-archive
+### logbook:archive
 
 Archiviert die Logbucheinträge mit einem definierten Alter, gemäß den Einstellungen auf der i-doit Oberfläche.
 
@@ -861,6 +861,7 @@ Archiviert die Logbucheinträge mit einem definierten Alter, gemäß den Einstel
 
 | Parameter (Kurzform) | Parameter (Langform)   | Beschreibung                                                                                     |
 | -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------ |
+|                      | --batch=[BATCHSIZE]    | Anzahl der Einträge, die pro Batch archiviert werden sollen [Standard: 1000]                     |
 | -u                   | --user=[USERNAME]      | Username eines Benutzers, der zur Ausführung berechtigt ist                                      |
 | -p                   | --password=[PASSWORD]  | Passwort zur Authentifizierung des zuvor angegebenen Benutzers                                   |
 | -i                   | --tenantId=[TENANT-ID] | Mandanten ID des Mandanten, der verwendet werden soll (Standard: 1)                              |
@@ -875,7 +876,7 @@ Archiviert die Logbucheinträge mit einem definierten Alter, gemäß den Einstel
 **Beispiel zur Verwendung**
 
 ```shell
-sudo -u www-data php console.php logbook-archive --user admin --password admin --tenantId 1
+sudo -u www-data php console.php logbook:archive --user admin --password admin --tenantId 1
 ```
 
 ### migrate-uploaded-files

--- a/docs/de/automatisierung-und-integration/cli/index.md
+++ b/docs/de/automatisierung-und-integration/cli/index.md
@@ -266,7 +266,6 @@ Available commands:
     license-list                        Liste der Lizenzen: ID, Produkt, Typ (Lizenztyp), Von (Lizenzbeginn), Ablaufen (Ablaufdatum der Lizenz), Lizenziert (max. Anzahl lizenzierter Objekte), Mandanten (max. Anzahl Mandanten)
     license-remove                      Lizenz aus i-doit entfernen
     list                                Befehle auflisten
-    logbook-archive                     Archiviert Logbuch-Einträge (Einstellungen werden in der GUI definiert)
     migrate-uploaded-files              Migriert hochgeladene Dateien in i-doit <v1.13 zu v.1.14>
     notifications-list                  Listet alle Benachrichtigungstypen und Benachrichtigungen zur späteren Verwendung auf
     notifications-send                  Versendet E-Mails für Benachrichtigungen, die im Benachrichtigungs Add-on definiert sind
@@ -298,6 +297,8 @@ idoit
     idoit:feature-manager               [idoit:fm] Mit diesem Befehl wird es möglich sein, eine Reihe von Features in i-doit zu aktivieren.
     idoit:set-env-var                   Mit diesem Befehl wird es möglich sein, Umgebungsvariablen für i-doit zu setzen.
     idoit:set-update-capability         Die i-doit-Update-Fähigkeit de- und aktivieren
+logbook
+    logbook:archive                     Archiviert Logbuch-Einträge (Einstellungen werden in der GUI definiert)
 system
     system:tenant-export                Exportieren Sie Ihre Mandantendaten einschließlich hochgeladener Dateien in ein ZIP-Paket.
     system:tenant-import                Importieren Sie Ihre Mandantendaten einschließlich hochgeladener Dateien aus einem ZIP-Paket, das mit dem Befehl system:tenant-export generiert wurde.

--- a/docs/de/grundlagen/logbuch.md
+++ b/docs/de/grundlagen/logbuch.md
@@ -76,7 +76,7 @@ Das Logbuch nimmt neue Einträge aus Dritt-Systemen entgegen, beispielsweise dur
 Beispiel:
 
 ```shell
-    sudo -u www-data php console.php logbook-archive --user admin --password admin --tenantId 1
+    sudo -u www-data php console.php logbook:archive --user admin --password admin --tenantId 1
 ```
 
 Archivierte Einträge lassen sich zur weiteren Auswertung wiederherstellen. Dieser Punkt befindet sich unter **Extras → CMDB → Logbuch → Wiederherstellen**.

--- a/docs/de/i-doit-add-ons/flows/actions/call-command.md
+++ b/docs/de/i-doit-add-ons/flows/actions/call-command.md
@@ -20,7 +20,7 @@ Die folgenden [console commands](../../../automatisierung-und-integration/cli/in
 | [jdisc:discovery](#jdiscdiscovery)                              | Löst einen JDisc-Discovery-Job aus.                                                                               |
 | [ldap-sync](#ldap-sync)                                         | Synchronisiert Benutzer und Gruppen von LDAP nach i-doit und legt sie als Objekte an.                             |
 | [ldap-syncdn](#ldap-syncdn)                                     | Synchronisiert LDAP-DNs mit den i-doit-Benutzern.                                                                 |
-| [logbook-archive](#logbook-archive)                             | Archiviert die Logbuch-Einträge mit einem definierten Alter gemäß den Einstellungen auf der i-doit-Oberfläche.    |
+| [logbook:archive](#logbookarchive)                              | Archiviert die Logbuch-Einträge mit einem definierten Alter gemäß den Einstellungen auf der i-doit-Oberfläche.    |
 | [notifications-send](#notifications-send)                       | Versendet die auf der i-doit-Oberfläche konfigurierten Benachrichtigungen.                                        |
 | [search-index](#search-index)                                   | Stellt den Suchindex wieder her, indem er gelöscht und neu geschrieben wird.                                      |
 | [sync-dynamic-groups](#sync-dynamic-groups)                     | Synchronisiert die Mitglieder dynamischer Gruppen neu.                                                            |
@@ -102,7 +102,7 @@ Verlängert automatisch die Laufzeit von ungekündigten Verträgen. Ein Anwendun
 | ---------------- | ------------------------------------ |
 | **ldapServerId** | Angabe des LDAP-Servers über die ID. |
 
-## logbook-archive
+## logbook:archive
 
 Archiviert die Logbuch-Einträge mit einem definierten Alter gemäß den Einstellungen auf der i-doit-Oberfläche.
 

--- a/docs/de/wartung-und-betrieb/cronjobs-einrichten.md
+++ b/docs/de/wartung-und-betrieb/cronjobs-einrichten.md
@@ -156,8 +156,8 @@ Dieses Script bekommt folgenden Inhalt:
         test "$(whoami)" != "$APACHE_USER" && prefix="sudo -u $APACHE_USER "
 
         log "Archive i-doit logbook"
-        eval "${prefix}${CONSOLE_BIN} logbook-archive $suffix" || \
-            abort "Command 'logbook-archive' failed"
+        eval "${prefix}${CONSOLE_BIN} logbook:archive $suffix" || \
+            abort "Command 'logbook:archive' failed"
         log ""
 
         log "Cleanup i-doit rights"

--- a/docs/en/automation-and-integration/cli/commands-and-options.md
+++ b/docs/en/automation-and-integration/cli/commands-and-options.md
@@ -48,7 +48,7 @@ lang: en
 | [license-list](#license-list)                                             | Lists all licenses with all information (ID; product; type; start date; end date; licensed objects; licensed clients; environment) |
 | [license-remove](#license-remove)                                         | Removes licenses from i-doit                                                                                                       |
 | [list](#list)                                                             | Lists all commands                                                                                                                 |
-| [logbook-archive](#logbook-archive)                                       | Archiving logbook entries                                                                                                          |
+| [logbook:archive](#logbookarchive)                                        | Archiving logbook entries                                                                                                          |
 | [migrate-uploaded-files](#migrate-uploaded-files)                         | Migrates uploaded files in i-doit <v1.13 to v.1.14>                                                                                |
 | [notifications-list](#notifications-list)                                 | Lists all notification types and notifications for later usage                                                                     |
 | [notifications-send](#notifications-send)                                 | Send notifications by e-mail (notifications are configured in the GUI)                                                             |
@@ -856,7 +856,7 @@ Deletes a license from i-doit
 sudo -u www-data php console.php license-remove --user admin --password admin --license LicenseID
 ```
 
-### logbook-archive
+### logbook:archive
 
 Archives the logbook entries with a defined age, according to the settings on the i-doit interface.
 
@@ -864,6 +864,7 @@ Archives the logbook entries with a defined age, according to the settings on th
 
 | Parameter (short version) | Parameter (long version) | Description                                                                                  |
 | ------------------------- | ------------------------ | -------------------------------------------------------------------------------------------- |
+|                           | --batch=BATCHSIZE        | Number of entries to be archived per batch [Default: 1000]                                   |
 | -u                        | --user=USERNAME          | Username of a user who is authorized to execute                                              |
 | -p                        | --password=PASSWORD      | Password for authentication of the previously specified user                                 |
 | -i                        | --tenantId=TENANT-ID     | Tenant ID of the tenant to be used (default: 1)                                              |
@@ -878,7 +879,7 @@ Archives the logbook entries with a defined age, according to the settings on th
 **Example of use**
 
 ```shell
-sudo -u www-data php console.php logbook-archive --user admin --password admin --tenantId 1
+sudo -u www-data php console.php logbook:archive --user admin --password admin --tenantId 1
 ```
 
 ### migrate-uploaded-files

--- a/docs/en/automation-and-integration/cli/index.md
+++ b/docs/en/automation-and-integration/cli/index.md
@@ -266,7 +266,6 @@ Available commands:
     license-list                        List of the licenses:  ID, Product, Type (type of license), From (start of license), Expire (expiration date of license), Licensed (max amount of licensed objects), Tenants (max amount of tenants), Environment
     license-remove                      Remove license from i-doit
     list                                List commands
-    logbook-archive                     Archives Logbook entries (Settings are defined in the GUI)
     migrate-uploaded-files              Migrates uploaded files in i-doit <v1.13 to v.1.14>
     notifications-list                  Lists all notification types and notifications for later usage
     notifications-send                  Sends out e-mails for notifications defined in the notification add-on
@@ -298,6 +297,8 @@ idoit
     idoit:feature-manager               [idoit:fm] With this command it will be possible to activate a set of features in i-doit.
     idoit:set-env-var                   With this command it will be possible to set environmental variables for i-doit.
     idoit:set-update-capability         Dis- and enable the i-doit update capability
+logbook
+    logbook:archive                     Archives Logbook entries (Settings are defined in the GUI)
 system
     system:tenant-export                Export your tenant data including uploaded files in a ZIP package.
     system:tenant-import                Import your tenant data including uploaded files from a ZIP package generated from the system:tenant-export command.

--- a/docs/en/automation-and-integration/task-scheduling-and-cronjobs.md
+++ b/docs/en/automation-and-integration/task-scheduling-and-cronjobs.md
@@ -34,8 +34,8 @@ set IDOIT_PASSWORD="admin"
 set TENANT_ID="1"
 
 :: Commands
-:: Logbook-Archive: Archives the logbook entries with a predefined age, according to the settings on the i-doit interface.
-C:\ProgramData\i-doit\php\php.exe C:\ProgramData\i-doit\apache-2.4\htdocs\console.php logbook-archive --user %IDOIT_USERNAME% --password %IDOIT_PASSWORD% --tenantId %TENANT_ID%
+:: Logbook:Archive: Archives the logbook entries with a predefined age, according to the settings on the i-doit interface.
+C:\ProgramData\i-doit\php\php.exe C:\ProgramData\i-doit\apache-2.4\htdocs\console.php logbook:archive --user %IDOIT_USERNAME% --password %IDOIT_PASSWORD% --tenantId %TENANT_ID%
 
 :: Search-Index: Renews the search index by deleting and rewriting it.
 C:\ProgramData\i-doit\php\php.exe C:\ProgramData\i-doit\apache-2.4\htdocs\console.php search-index --user %IDOIT_USERNAME% --password %IDOIT_PASSWORD% --tenantId %TENANT_ID%

--- a/docs/en/basics/logbook.md
+++ b/docs/en/basics/logbook.md
@@ -71,12 +71,12 @@ Whether older entries are to be archived or not can be configured via **Extras �
 
 [![Archiving and Restoring Older Entries](../assets/images/en/basics/logbook/8-lb.png)](../assets/images/en/basics/logbook/8-lb.png)
 
-Archiving is performed via the [i-doit Console](../i-doit-add-ons/api/index.md). This step can therefore also be automated. A corresponding example of a call and a [list of parameters](../automation-and-integration/cli/index.md) can be found in the corresponding article for the [logbook-archive](../automation-and-integration/cli/index.md) option.
+Archiving is performed via the [i-doit Console](../i-doit-add-ons/api/index.md). This step can therefore also be automated. A corresponding example of a call and a [list of parameters](../automation-and-integration/cli/index.md) can be found in the corresponding article for the [logbook:archive](../automation-and-integration/cli/index.md) option.
 
 Example:
 
 ```shell
-sudo -u www-data php console.php logbook-archive --user admin --password admin --tenantId 1
+sudo -u www-data php console.php logbook:archive --user admin --password admin --tenantId 1
 ```
 
 Archived entries can be restored for further evaluation. This item can be found under **Extras → CMDB → Logbook → Restore**.

--- a/docs/en/i-doit-add-ons/flows/actions/call-command.md
+++ b/docs/en/i-doit-add-ons/flows/actions/call-command.md
@@ -20,7 +20,7 @@ The following [console commands](../../../automation-and-integration/cli/index.m
 | [jdisc:import](#jdiscimport)                                       | Performs a JDisc import to i-doit                                                                  |
 | [ldap-sync](#ldap-sync)                                            | Synchronizes user and groups from LDAP to i-doit and creates them as objects                       |
 | [ldap-syncdn](#ldap-syncdn)                                        | Synchronizes LDAP DNs with the i-doit users                                                        |
-| [logbook-archive](#logbook-archive)                                | Archives the logbook entries with a defined age, according to the settings on the i-doit interface |
+| [logbook:archive](#logbookarchive)                                 | Archives the logbook entries with a defined age, according to the settings on the i-doit interface |
 | [notifications-send](#notifications-send)                          | Sends the notifications configured on the i-doit interface                                         |
 | [search-index](#search-index)                                      | Restores the search index by deleting and rewriting it                                             |
 | [sync-dynamic-groups](#sync-dynamic-groups)                        | Resynchronizes dynamic group members                                                               |
@@ -102,7 +102,7 @@ Automatically extend the runtime of not-cancelled contracts. A Use case can be f
 | ---------------- | ------------------------------------- |
 | **ldapServerId** | Specifying the LDAP server via the ID |
 
-## logbook-archive
+## logbook:archive
 
 Archives the logbook entries with a defined age, according to the settings on the i-doit interface.
 

--- a/docs/en/maintenance-and-operation/cronjob-setup.md
+++ b/docs/en/maintenance-and-operation/cronjob-setup.md
@@ -8,7 +8,7 @@ The setup of cronjobs is optional. However, we definitely recommend using this o
 
     The setup of cronjobs is optional. However, we definitely recommend using this option, at best directly after the [installation](../installation/index.md).
 
-Simplify Access of the Controller  
+Simplify Access of the Controller
 ------------------------------------
 
 To simplify the process to access the controller, you can use a simple bash script:
@@ -18,11 +18,11 @@ To simplify the process to access the controller, you can use a simple bash scri
 The script gets the following contents which have to be adapted to your own installation:
 
     #!/bin/bash
-    
+
     ##
     ## i-doit console
     ##
-    
+
     ##
     ## Copyright (C) 2017-18 synetics GmbH, <https://i-doit.com/>
     ##
@@ -39,53 +39,53 @@ The script gets the following contents which have to be adapted to your own inst
     ## You should have received a copy of the GNU Affero General Public License
     ## along with this program. If not, see <http://www.gnu.org/licenses/>.
     ##
-    
+
     set -euo pipefail
-    
+
     ##
     ## Configuration
     ##
-    
+
     INSTANCE_PATH="/var/www/html/"
     APACHE_USER="www-data"
     ARGS="$*"
-    
+
     ##--------------------------------------------------------------------------------------------------
-    
+
     function execute {
         local prefix=""
         local console="php console.php $ARGS"
-    
+
         test "$(whoami)" != "$APACHE_USER" && prefix="sudo -u $APACHE_USER "
-    
+
         eval "${prefix}${console}" || abort "i-doit console exited with non-zero status"
     }
-    
+
     function setup {
         cd "$INSTANCE_PATH" || abort "No i-doit instance found under '${INSTANCE_PATH}'"
     }
-    
+
     function finish {
         exit 0
     }
-    
+
     function abort {
         echo -e "$1"  1>&2
         echo "Operation failed. Please check what is wrong and try again." 1>&2
         exit 1
     }
-    
+
     function log {
         echo -e "$1"
     }
-    
+
     ##--------------------------------------------------------------------------------------------------
-    
+
     if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
         setup && execute && finish
     fi
 
-Afterwards, the execution of the script is enabled:  
+Afterwards, the execution of the script is enabled:
 
     sudo chmod +x /usr/local/bin/idoit
 
@@ -112,11 +112,11 @@ In the next step we create another script which we can call up both manually and
 This script gets the following contents:
 
     #!/bin/bash
-    
+
     ##
     ## i-doit jobs
     ##
-    
+
     ##
     ## Copyright (C) 2017-18 synetics GmbH, <https://i-doit.com/>
     ##
@@ -133,91 +133,91 @@ This script gets the following contents:
     ## You should have received a copy of the GNU Affero General Public License
     ## along with this program. If not, see <http://www.gnu.org/licenses/>.
     ##
-    
+
     set -euo pipefail
     IFS=$'\n\t'
-    
+
     ##
     ## Configuration
     ##
-    
+
     CONSOLE_BIN="/usr/local/bin/idoit"
     INSTANCE_PATH="/var/www/html/"
     APACHE_USER="www-data"
     IDOIT_USERNAME="admin"
     IDOIT_PASSWORD="admin"
     TENANT_ID="1"
-    
+
     ##--------------------------------------------------------------------------------------------------
-    
+
     function execute {
         local prefix=""
         local suffix="--user $IDOIT_USERNAME --password $IDOIT_PASSWORD --tenantId $TENANT_ID"
-    
+
         test "$(whoami)" != "$APACHE_USER" && prefix="sudo -u $APACHE_USER "
-    
+
         log "Archive i-doit logbook"
-        eval "${prefix}${CONSOLE_BIN} logbook-archive $suffix" || \
-            abort "Command 'logbook-archive' failed"
+        eval "${prefix}${CONSOLE_BIN} logbook:archive $suffix" || \
+            abort "Command 'logbook:archive' failed"
         log ""
-    
+
         log "Cleanup i-doit rights"
         eval "${prefix}${CONSOLE_BIN} auth-cleanup $suffix" || \
             abort "Command 'auth-cleanup' failed"
         log ""
-    
+
         log "Purge unfinished objects"
         eval "${prefix}${CONSOLE_BIN} system-objectcleanup --objectStatus 1 $suffix" || \
             abort "Command 'system-objectcleanup' failed"
         log ""
-    
+
         log "Re-create search index"
         eval "${prefix}${CONSOLE_BIN} search-index $suffix" || \
             abort "Command 'search-index' failed"
-    
+
         log "Send notifications"
         eval "${prefix}${CONSOLE_BIN} notifications-send $suffix" || \
             abort "Command 'notifications-send' failed"
-    
+
         log "Clear caches"
         eval "${prefix}rm -rf ${INSTANCE_PATH}/temp/*" || \
             abort "Unable to clear caches"
-    
+
         log "Clear updates"
         eval "${prefix}rm -rf ${INSTANCE_PATH}/updates/versions/*" || \
             abort "Unable to clear updates"
     }
-    
+
     function setup {
         test -x "$CONSOLE_BIN" || \
             abort "Script '${CONSOLE_BIN}' not found"
-    
+
         test -d "$INSTANCE_PATH" || \
             abort "No i-doit instance found under '${INSTANCE_PATH}'"
     }
-    
+
     function log {
         echo -e "$1"
     }
-    
+
     function finish {
         log "Done. Have fun :-)"
         exit 0
     }
-    
+
     function abort {
         echo -e "$1"  1>&2
         echo "Operation failed. Please check what is wrong and try again." 1>&2
         exit 1
     }
-    
+
     ##--------------------------------------------------------------------------------------------------
-    
+
     if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
         setup && execute && finish
     fi
 
-Afterwards, the execution of the script is enabled:  
+Afterwards, the execution of the script is enabled:
 
     sudo chmod +x /usr/local/bin/idoit-jobs
 
@@ -225,7 +225,7 @@ From now on, every user can use it:
 
     idoit-jobs
 
-The following tasks are carried out when the script is executed:  
+The following tasks are carried out when the script is executed:
 
 *   File caches in the **temp/** directory are emptied.
 *   [Update packages](../maintenance-and-operation/update.md) which are not required anymore are deleted.
@@ -233,16 +233,16 @@ The following tasks are carried out when the script is executed:
 *   The cache for [user rights](../efficient-documentation/rights-management/index.md) is build up afresh.
 *   ["Unfinished" objects](../basics/life-and-documentation-cycle.md) are deleted irrevocably.
 *   The [search index](../efficient-documentation/search.md) is created freshly.
-*   [Notifications](../evaluation/notifications.md) are sent via e-mail.  
+*   [Notifications](../evaluation/notifications.md) are sent via e-mail.
 
 Automation of Jobs Calls
 ------------------------
 
-### When and how often?  
+### When and how often?
 
 We recommend executing the above mentioned jobs at least once per day. You should ensure that no other interactions are carried out in i-doit during the execution - neither via the web GUI nor through additional scripts or by external applications via the API. Therefore the jobs are usually carried out during the night.
 
-### GNU/Linux  
+### GNU/Linux
 
 Under Linux you can run automated commands on a regular basis. You could use [cron, anacron, crontab](https://de.wikipedia.org/wiki/Cron) or [systemd.timer](https://www.freedesktop.org/software/systemd/man/systemd.timer.html).
 

--- a/docs/en/system-administration/administration/logbook.md
+++ b/docs/en/system-administration/administration/logbook.md
@@ -39,7 +39,7 @@ Enter for how long entries in the logbook should be kept before they will be arc
 | Entries older than | Value in Days                     |
 | Destination        | local database<br>remote database |
 
-To archive the logbook, the [logbook-archive](../../automation-and-integration/cli/index.md) CLI command must be executed.
+To archive the logbook, the [logbook:archive](../../automation-and-integration/cli/index.md) CLI command must be executed.
 
 ## Restore
 


### PR DESCRIPTION
Update the logbook command from `logbook-archive` to `logbook:archive` across documentation and scripts for consistency and clarity. This change aligns with the updated command structure in the i-doit interface.