### PR TITLE
Remove redundant text from CLI documentation

### DIFF
--- a/docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md
+++ b/docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md
@@ -1664,7 +1664,3 @@ Importieren Sie Ihre Mandantendaten inklusive hochgeladener Dateien aus einem ZI
 |                      | --ansi<br>--no-ansi                         | ANSI-Ausgabe erzwingen (oder --no-ansi deaktivieren)                                                                                                                                                                                                                                                         |
 | -n                   | --no-interaction                            | Deaktiviert sämtliche Interaktionsfragen der i-doit Console                                                                                                                                                                                                                                                  |
 | -v / -vv / -vvv      | --verbose                                   | Erhöht den Umfang der Rückgabe. (1 = Normale Ausgabe, 2 = Detaillierte Ausgabe, 3 = Debug-Level)                                                                                                                                                                                                             |
-
-If set, system.settings.json will be imported and overwrites the current settings of the system
-
-All settings which already exists but are not defined in system.settings.json will stay untouched

--- a/docs/en/automation-and-integration/cli/commands-and-options.md
+++ b/docs/en/automation-and-integration/cli/commands-and-options.md
@@ -1671,6 +1671,3 @@ Import your tenant data from a ZIP package created by the tenant-export command.
 |                           | --ansi<br>--no-ansi                         | Force (or disable --no-ansi) ANSI output                                                                                                                                                                                           |
 | -n                        | --no-interaction                            | Disables all interaction questions of the i-doit Console                                                                                                                                                                           |
 | -v / -vv / -vvv           | --verbose                                   | Increases the scope of the return. (1 = normal output, 2 = detailed output, 3 = debug level)                                                                                                                                       |
-If set, system.settings.json will be imported and overwrites the current settings of the system
-
-All settings which already exists but are not defined in system.settings.json will stay untouched


### PR DESCRIPTION
Eliminate unnecessary information regarding `system.settings.json` in the CLI documentation to enhance clarity.