### PR TITLE
Remove version information from JDisc Connector documentation

### DIFF
--- a/docs/de/i-doit-add-ons/jdisc-connector/index.md
+++ b/docs/de/i-doit-add-ons/jdisc-connector/index.md
@@ -6,10 +6,6 @@ status: new
 lang: de
 ---
 
-# JDisc Connector
-
-!!! success "Aktuell ist Version 1.0.1"
-
 ## Übersicht
 
 Der **JDisc Connector** ist ein Add-on für i-doit, das den automatisierten Import von IT-Objekten aus einer JDisc-Instanz ermöglicht. Die Integration basiert auf der GraphQL-Schnittstelle von JDisc und erlaubt eine präzise Synchronisation von Geräten und deren Eigenschaften in die CMDB von i-doit.

--- a/docs/en/i-doit-add-ons/jdisc-connector/index.md
+++ b/docs/en/i-doit-add-ons/jdisc-connector/index.md
@@ -6,10 +6,6 @@ status: new
 lang: en
 ---
 
-# JDisc Connector
-
-!!! success "The current version is 1.0.1"
-
 ## Overview
 
 The **JDisc Connector** is an add-on for i-doit that enables automated import of IT objects from a JDisc instance. The integration is based on JDisc's GraphQL interface and allows precise synchronization of devices and their properties into the i-doit CMDB.


### PR DESCRIPTION
Remove specific version information from the JDisc Connector documentation to keep it general and avoid outdated references.