### PR TITLE
Update search tips for MAC address formats

### DIFF
--- a/docs/de/effizientes-dokumentieren/suche.md
+++ b/docs/de/effizientes-dokumentieren/suche.md
@@ -219,3 +219,7 @@ Hier ein Beispiel bei dem das Limit auf 5000 Ergebnisse gesetzt wurde.
 ### Tipps zur Suche
 
 IPv6 Adressen lassen sich auch mit gekürzten Schreibweisen finden. So kann beispielsweise die Adresse "2001:0db8:85a3:0000:0000:8a2e:0370:7334" auch mit "2001:db8:85a3::8a2e:370:7334" gefunden werden. Es ist also nicht notwendig, die vollständige Adresse einzugeben, um das gewünschte Ergebnis zu erhalten.
+
+---
+
+Es ist auch möglich MAC-Adressen mit Doppelpunkt, ohne Trennzeichen oder in 4er Blöcken zu suchen. So kann beispielsweise die Adresse "00:1A:2B:3C:4D:5E" auch mit "001A2B3C4D5E" oder "001A.2B3C.4D5E" gefunden werden. Es ist also nicht notwendig, die Trennzeichen einzugeben, um das gewünschte Ergebnis zu erhalten.

--- a/docs/en/efficient-documentation/search.md
+++ b/docs/en/efficient-documentation/search.md
@@ -206,3 +206,7 @@ Here is an example where the limit was set to 5000 results.
 ### Tips for Searching
 
 IPv6 addresses can also be found with shortened notations. For example, the address "2001:0db8:85a3:0000:0000:8a2e:0370:7334" can also be found with "2001:db8:85a3::8a2e:370:7334". It is therefore not necessary to enter the full address to get the desired result.
+
+---
+
+It is also possible to search for MAC addresses with colons, without separators, or in blocks of 4. For example, the address "00:1A:2B:3C:4D:5E" can also be found with "001A2B3C4D5E" or "001A.2B3C.4D5E". It is therefore not necessary to enter the separators to get the desired result.


### PR DESCRIPTION
Enhance documentation to clarify that MAC addresses can be searched using various formats, including with colons, without separators, or in blocks of four.