### PR TITLE
docs(docker): rename synetics to i-doit group, drop stale Setup link

### DIFF
--- a/docs/de/installation/docker-installation/compose.md
+++ b/docs/de/installation/docker-installation/compose.md
@@ -1,6 +1,6 @@
 ---
 title: Docker-Installation mit i-doit-Images
-description: i-doit Pro als Container-Stack mit den offiziellen synetics-Images installieren
+description: i-doit Pro als Container-Stack mit den offiziellen Images der i-doit group installieren
 icon: material/docker
 status:
 lang: de
@@ -8,7 +8,7 @@ lang: de
 
 !!! note "Getestet mit i-doit **38** und **Debian 13 Trixie**"
 
-Diese Anleitung beschreibt die Installation von i-doit Pro mit den offiziellen synetics-Container-Images über Docker Compose. Der Stack besteht aus zwei Services — `app` (Apache + PHP + i-doit) und `db` (MariaDB) — und ist auf einem Linux-Server in wenigen Minuten einsatzbereit.
+Diese Anleitung beschreibt die Installation von i-doit Pro mit den offiziellen Container-Images der i-doit group über Docker Compose. Der Stack besteht aus zwei Services — `app` (Apache + PHP + i-doit) und `db` (MariaDB) — und ist auf einem Linux-Server in wenigen Minuten einsatzbereit.
 
 Für TLS-Termination wird optional ein dritter Service mit nginx ergänzt.
 
@@ -346,7 +346,7 @@ i-doit Pro benötigt zur Aktivierung einen gültigen Lizenz-Token oder eine Lize
 
 ### Variante A — Web-Lizenz-Token
 
-Token aus dem synetics Kundenportal kopieren, in die `.env` eintragen und den `app`-Container neu starten:
+Token aus dem Kundenportal der i-doit group kopieren, in die `.env` eintragen und den `app`-Container neu starten:
 <!-- cSpell:disable -->
 ```sh
 sudo sed -i 's/^IDOIT_LICENSE_TOKEN=.*/IDOIT_LICENSE_TOKEN=<token>/' /opt/idoit/.env
@@ -530,8 +530,3 @@ sudo docker compose logs --tail 100 app
 ```
 <!-- cSpell:enable -->
 
-## Nächster Schritt
-
-Die Installation ist abgeschlossen. Im nächsten Schritt eine Lizenz einspielen und die ersten Einstellungen vornehmen:
-
-[Weiter zu **Setup**](../manuelle-installation/setup.md)

--- a/docs/de/installation/docker-installation/index.md
+++ b/docs/de/installation/docker-installation/index.md
@@ -8,7 +8,7 @@ lang: de
 
 # Docker Installation
 
-i-doit lässt sich vollständig in Docker-Containern betreiben. Es stehen zwei Installationspfade zur Verfügung — entweder mit den offiziellen synetics-Container-Images (empfohlen, schnellster Weg) oder mit selbst gebauten Containern auf Basis einer ausgewählten Linux-Distribution.
+i-doit lässt sich vollständig in Docker-Containern betreiben. Es stehen zwei Installationspfade zur Verfügung — entweder mit den offiziellen Container-Images der i-doit group (empfohlen, schnellster Weg) oder mit selbst gebauten Containern auf Basis einer ausgewählten Linux-Distribution.
 
 ## Voraussetzungen
 
@@ -19,9 +19,9 @@ i-doit lässt sich vollständig in Docker-Containern betreiben. Es stehen zwei I
 
 ## Installationspfade
 
-### Mit offiziellen synetics-Images (empfohlen)
+### Mit offiziellen Images der i-doit group (empfohlen)
 
-Vorgefertigter Stack aus zwei gehärteten Containern (`app` mit Apache + PHP + i-doit, `db` mit MariaDB). Die Images werden öffentlich von synetics bereitgestellt — kein Image-Build nötig, schnelleres Setup, integrierte Healthchecks. Optional erweitert um nginx für TLS-Termination.
+Vorgefertigter Stack aus zwei gehärteten Containern (`app` mit Apache + PHP + i-doit, `db` mit MariaDB). Die Images werden öffentlich von der i-doit group bereitgestellt — kein Image-Build nötig, schnelleres Setup, integrierte Healthchecks. Optional erweitert um nginx für TLS-Termination.
 
 | Container | Image | Aufgabe |
 |-----------|-------|---------|

--- a/docs/en/installation/docker-installation/compose.md
+++ b/docs/en/installation/docker-installation/compose.md
@@ -1,6 +1,6 @@
 ---
 title: Docker installation with official i-doit images
-description: Install i-doit Pro as a container stack using the official synetics images
+description: Install i-doit Pro as a container stack using the official images from the i-doit group
 icon: material/docker
 status:
 lang: en
@@ -8,7 +8,7 @@ lang: en
 
 !!! note "Tested with i-doit **38** and **Debian 13 Trixie**"
 
-This guide describes how to install i-doit Pro using the official synetics container images via Docker Compose. The stack consists of two services — `app` (Apache + PHP + i-doit) and `db` (MariaDB) — and is ready to use on a Linux server within a few minutes.
+This guide describes how to install i-doit Pro using the official container images from the i-doit group via Docker Compose. The stack consists of two services — `app` (Apache + PHP + i-doit) and `db` (MariaDB) — and is ready to use on a Linux server within a few minutes.
 
 For TLS termination, an optional third service running nginx is added.
 
@@ -346,7 +346,7 @@ i-doit Pro requires a valid license token or license file to activate. The shipp
 
 ### Variant A — web license token
 
-Copy the token from the synetics customer portal, write it to the `.env`, and restart the `app` container:
+Copy the token from the i-doit group customer portal, write it to the `.env`, and restart the `app` container:
 <!-- cSpell:disable -->
 ```sh
 sudo sed -i 's/^IDOIT_LICENSE_TOKEN=.*/IDOIT_LICENSE_TOKEN=<token>/' /opt/idoit/.env
@@ -530,8 +530,3 @@ sudo docker compose logs --tail 100 app
 ```
 <!-- cSpell:enable -->
 
-## Next step
-
-The installation is complete. Next, install a license and apply the initial settings:
-
-[Continue to **Setup**](../manual-installation/setup.md)

--- a/docs/en/installation/docker-installation/index.md
+++ b/docs/en/installation/docker-installation/index.md
@@ -8,7 +8,7 @@ lang: en
 
 # Docker Installation
 
-i-doit can be fully operated in Docker containers. Two installation paths are available — either with the official synetics container images (recommended, fastest path) or with self-built containers based on a chosen Linux distribution.
+i-doit can be fully operated in Docker containers. Two installation paths are available — either with the official container images from the i-doit group (recommended, fastest path) or with self-built containers based on a chosen Linux distribution.
 
 ## Requirements
 
@@ -19,9 +19,9 @@ i-doit can be fully operated in Docker containers. Two installation paths are av
 
 ## Installation paths
 
-### With official synetics images (recommended)
+### With official images from the i-doit group (recommended)
 
-Prebuilt stack of two hardened containers (`app` with Apache + PHP + i-doit, `db` with MariaDB). The images are provided publicly by synetics — no image build required, faster setup, integrated healthchecks. Optionally extended by nginx for TLS termination.
+Prebuilt stack of two hardened containers (`app` with Apache + PHP + i-doit, `db` with MariaDB). The images are provided publicly by the i-doit group — no image build required, faster setup, integrated healthchecks. Optionally extended by nginx for TLS termination.
 
 | Container | Image | Purpose |
 |-----------|-------|---------|


### PR DESCRIPTION
## Summary

Two follow-up corrections to the Docker installation pages added in #1306 / #1307:

- **Naming**: Replace \"synetics\" with \"i-doit group\" throughout the descriptions and customer-portal reference in both the German and English variants of `compose.md` and `index.md`. Registry hostnames (`registry.on.ops.docupike.net/...`) and image paths are unchanged.
- **Dead link**: Drop the trailing \"Next step\" block that linked to `../manual-installation/setup.md`. The Compose guide is self-contained — first login, Pro-mode activation and license install are all covered in-place — so the manual-install setup page is no longer the natural follow-up.

## Why

Surfaced when reading the rendered page on kb.i-doit.com: the \"synetics\" mentions don't match the current company name, and the \"Continue to Setup\" link at the end of the Compose guide pointed at a step that has already happened earlier on the same page.

## Test plan

- [x] \`grep -i synetics docs/{de,en}/installation/docker-installation/{compose,index}.md\` returns no hits.
- [x] No remaining \`setup.md\` link or \"Continue to / Weiter zu\" trailer in either compose.md.
- [x] All other content unchanged (registry hostnames, image paths, code blocks, troubleshooting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)