### PR TITLE
fix: redirect /system-administration/reset-token to administration/reset-token

### DIFF
--- a/config/de/mkdocs.yml
+++ b/config/de/mkdocs.yml
@@ -65,6 +65,7 @@ plugins:
       strict: false
   - redirects:
       redirect_maps:
+        'system-administration/reset-token.md': 'administration/reset-token.md'
         'i-doit-add-ons/isms.md': 'i-doit-add-ons/isms/index.md'
         'i-doit-add-ons/viva2.md': 'i-doit-add-ons/viva2/index.md'
         'wartung-und-betrieb/lizenz-aktivieren.md': 'wartung-und-betrieb/lizenzierung.md'

--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -65,6 +65,7 @@ plugins:
       strict: false
   - redirects:
       redirect_maps:
+        'system-administration/reset-token.md': 'administration/reset-token.md'
         'i-doit-add-ons/isms.md': 'i-doit-add-ons/isms/index.md'
         'i-doit-add-ons/viva2.md': 'i-doit-add-ons/viva2/index.md'
         'wartung-und-betrieb/lizenz-aktivieren.md': 'maintenance-and-operation/licensing.md'


### PR DESCRIPTION
## Problem
The license token help page is linked from the product (Add-on & Subscription Center) as `/<lang>/system-administration/reset-token.html`, but the article actually lives at `docs/<lang>/administration/reset-token.md` (URL `/<lang>/administration/reset-token.html`). The product link therefore 404s.

## Change
Add a redirect entry to the `redirects` plugin in both language configs so the linked URL resolves to the existing page:

```yaml
'system-administration/reset-token.md': 'administration/reset-token.md'
```

- `config/en/mkdocs.yml`
- `config/de/mkdocs.yml`

No content moved, no nav change. Page stays canonical at `administration/reset-token.md`; the new mapping just routes the product link there.

## Test plan
- [ ] Build the docs and open `/en/system-administration/reset-token.html` -> should redirect to `/en/administration/reset-token.html`
- [ ] Same for `/de/...`