### PR TITLE
docs: add usage example for system:tenant-import

### DIFF
--- a/docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md
+++ b/docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md
@@ -1664,3 +1664,15 @@ Importiere deine Mandantendaten inklusive hochgeladener Dateien aus einem ZIP-Pa
 |                      | --ansi<br>--no-ansi                         | ANSI-Ausgabe erzwingen (oder --no-ansi deaktivieren)                                                                                                                                                                                                                                                         |
 | -n                   | --no-interaction                            | Deaktiviert sämtliche Interaktionsfragen der i-doit Console                                                                                                                                                                                                                                                  |
 | -v / -vv / -vvv      | --verbose                                   | Erhöht den Umfang der Rückgabe. (1 = Normale Ausgabe, 2 = Detaillierte Ausgabe, 3 = Debug-Level)                                                                                                                                                                                                             |
+
+**Beispiel zur Verwendung**
+
+```shell
+sudo -u www-data php /var/www/html/console.php system:tenant-import \
+    --file /pfad/zu/idoit-tenant-export.zip \
+    --tenant-database-name idoit_data \
+    --tenant-title "Mein Mandant" \
+    --db-root-user root \
+    --db-root-pass geheim \
+    --db-host localhost
+```

--- a/docs/en/automation-and-integration/cli/commands-and-options.md
+++ b/docs/en/automation-and-integration/cli/commands-and-options.md
@@ -1664,3 +1664,15 @@ Import your tenant data including uploaded files from a ZIP package.
 |                      | --ansi<br>--no-ansi                         | Force ANSI output (or disable with --no-ansi)                                                                                                                                                                                                                                                         |
 | -n                   | --no-interaction                            | Disables all interaction questions of the i-doit console                                                                                                                                                                                                                                                  |
 | -v / -vv / -vvv      | --verbose                                   | Increases the verbosity of output (1 = normal output, 2 = detailed output, 3 = debug level)                                                                                                                                                                                                             |
+
+**Usage example**
+
+```shell
+sudo -u www-data php /var/www/html/console.php system:tenant-import \
+    --file /path/to/idoit-tenant-export.zip \
+    --tenant-database-name idoit_data \
+    --tenant-title "My Tenant" \
+    --db-root-user root \
+    --db-root-pass secret \
+    --db-host localhost
+```


### PR DESCRIPTION
## Problem
In the CLI command reference (`commands-and-options.md` / `befehle-und-optionen.md`), `system:tenant-export` has a **Usage example** block, but `system:tenant-import` ends right after its options table with no example.

## Change
Add a matching usage example to both language files, mirroring the export example and the full restore invocation already used in the backup-and-restore article:

```shell
sudo -u www-data php /var/www/html/console.php system:tenant-import \
    --file /path/to/idoit-tenant-export.zip \
    --tenant-database-name idoit_data \
    --tenant-title "My Tenant" \
    --db-root-user root \
    --db-root-pass secret \
    --db-host localhost
```

- `docs/en/automation-and-integration/cli/commands-and-options.md`
- `docs/de/automatisierung-und-integration/cli/befehle-und-optionen.md`

## Test plan
- [ ] Build the docs; the `system:tenant-import` section now shows a usage example in EN and DE