### PR TITLE
Add print-friendly tables guidance to document templates

### DIFF
--- a/docs/de/i-doit-add-ons/documents/dokumentenvorlagen.md
+++ b/docs/de/i-doit-add-ons/documents/dokumentenvorlagen.md
@@ -65,6 +65,19 @@ Im Eingabefeld fügst du den Inhalt des Kapitels über den WYSIWYG-Editor ein. �
 | [![icon](../../assets/images/de/i-doit-add-ons/documents/vorlagen/11-vor.png)](../../assets/images/de/i-doit-add-ons/documents/vorlagen/11-vor.png) | Inhalte aus der Dokumentation bindest du dynamisch über [Platzhalter](./platzhalter-im-add-on-dokumente.md) ein. Details findest du [im entsprechenden Kapitel](./platzhalter-im-add-on-dokumente.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | [![icon](../../assets/images/de/i-doit-add-ons/documents/vorlagen/12-vor.png)](../../assets/images/de/i-doit-add-ons/documents/vorlagen/12-vor.png) | Hier fügst du einen automatischen Seitenumbruch ein.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
+## Druckoptimierte Tabellen
+
+Das PDF wird von einer anderen Engine erzeugt als der Browser-Editor. Sehr komplexe Tabellen-Layouts können daher im PDF anders aussehen als im Editor. Das betrifft Tabellen im Inhalt ebenso wie in der Kopf- und Fußzeile. Damit Tabellen im PDF zuverlässig dargestellt werden, beachtest du folgende Punkte:
+
+* Verwende relative Breiten (zum Beispiel die Tabelle auf 100 %) statt fester Pixelbreiten und halte die Gesamtbreite innerhalb der Seite.
+* Verwende über alle Zeilen einer Tabelle dieselben Spaltenbreiten.
+* Vermeide verbundene Zellen (colspan/rowspan) nach Möglichkeit und nutze stattdessen eine einheitliche Spaltenaufteilung.
+* Halte Kopf- und Fußzeile kompakt. Eine sehr hohe Kopfzeile verringert den Platz für den Inhalt.
+* Prüfe das Ergebnis vor dem Fertigstellen über die Vorschau, da die Editor-Ansicht nicht mit der PDF-Ausgabe identisch ist.
+
+!!! tip "Aus Word übernommene Inhalte"
+    Füge Tabellen nicht direkt aus Word oder anderen Office-Programmen ein. Dabei werden aufgeblähte Pixelbreiten und verstecktes Styling übernommen, das die PDF-Engine nicht auflösen kann. Füge den Inhalt als reinen Text ein und baue die Tabelle im Editor neu auf, oder bereinige sie in der Quellcode-Ansicht.
+
 ## Vorlagen exportieren und importieren
 
 Vorhandene Vorlagen exportierst du bei Bedarf und importierst sie in andere Mandanten oder i-doit-Installationen. Öffne dazu die Vorlage in der Bearbeitungsansicht und klicke auf "Dokumentvorlage exportieren". Die Vorlage wird als ZIP-Datei bereitgestellt, die alle Inhalte inklusive eingefügter Bilder enthält.

--- a/docs/en/i-doit-add-ons/documents/document-templates.md
+++ b/docs/en/i-doit-add-ons/documents/document-templates.md
@@ -65,6 +65,19 @@ In the input field, you add the chapter content via the WYSIWYG editor. Via the 
 | [![icon](../../assets/images/de/i-doit-add-ons/documents/vorlagen/11-vor.png)](../../assets/images/de/i-doit-add-ons/documents/vorlagen/11-vor.png) | You dynamically embed content from the documentation via [placeholders](./platzhalter-im-add-on-dokumente.md). Details can be found in the [corresponding chapter](./platzhalter-im-add-on-dokumente.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | [![icon](../../assets/images/de/i-doit-add-ons/documents/vorlagen/12-vor.png)](../../assets/images/de/i-doit-add-ons/documents/vorlagen/12-vor.png) | Here you insert an automatic page break.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
+## Print-friendly tables
+
+The PDF is rendered by a different engine than the browser editor, so very complex table layouts can appear differently in the PDF than in the editor. This applies to tables in the content as well as in the header and footer. To keep tables rendering reliably in the PDF, follow these guidelines:
+
+* Use relative widths (for example, set the table to 100%) instead of fixed pixel widths, and keep the total width within the page.
+* Use the same column widths across all rows of a table.
+* Avoid merged cells (colspan/rowspan) where possible and use a consistent column layout instead.
+* Keep the header and footer compact. A very tall header reduces the space available for the content.
+* After editing, check the result with the preview before you finalize the template, because the editor view is not identical to the PDF output.
+
+!!! tip "Content pasted from Word"
+    Do not paste tables directly from Word or other office programs. This carries over inflated pixel widths and hidden styling that the PDF engine cannot reconcile. Paste the content as plain text and rebuild the table in the editor, or clean it up in the source code view.
+
 ## Exporting and Importing Templates
 
 You can export existing templates and import them into other tenants or i-doit installations. To do this, open the template in the editing view and click "Export Document Template." The template is provided as a ZIP file containing all content including inserted images.


### PR DESCRIPTION
Adds a "Print-friendly tables" / "Druckoptimierte Tabellen" section to the Document Templates page (EN + DE), placed after the WYSIWYG editor section.

It explains how to author tables that render reliably in the PDF export: relative widths instead of fixed pixel widths, the same column widths across all rows, avoiding merged cells (colspan/rowspan), keeping the header and footer compact, and checking the preview. A tip warns against pasting tables directly from Word (inflated pixel widths and hidden styling).

Strict build passes for both languages (EN + DE).