### PR TITLE
docs(jdisc-connector): add Cloud and Kubernetes import guide

### DIFF
--- a/config/de/mkdocs.yml
+++ b/config/de/mkdocs.yml
@@ -880,7 +880,9 @@ nav:
           - Reporting: i-doit-add-ons/isms/reports.md
           - Objekttypen und Kategorien: i-doit-add-ons/isms/object-types-and-categories.md
           - Releases: i-doit-add-ons/isms/releases.md
-      - JDisc Connector: i-doit-add-ons/jdisc-connector/index.md
+      - JDisc Connector:
+          - i-doit-add-ons/jdisc-connector/index.md
+          - Cloud- und Kubernetes-Import: i-doit-add-ons/jdisc-connector/cloud-kubernetes-import.md
       - Maintenance: i-doit-add-ons/maintenance.md
       - Nagios: i-doit-add-ons/nagios.md
       - OCS Inventory NG: i-doit-add-ons/ocs-inventory-ng.md

--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -882,7 +882,9 @@ nav:
           - Reporting: i-doit-add-ons/isms/reports.md
           - Object Types and Categories: i-doit-add-ons/isms/object-types-and-categories.md
           - Releases: i-doit-add-ons/isms/releases.md
-      - JDisc Connector: i-doit-add-ons/jdisc-connector/index.md
+      - JDisc Connector:
+          - i-doit-add-ons/jdisc-connector/index.md
+          - Cloud and Kubernetes Import: i-doit-add-ons/jdisc-connector/cloud-kubernetes-import.md
       - Maintenance: i-doit-add-ons/maintenance.md
       - Nagios: i-doit-add-ons/nagios.md
       - OCS Inventory NG: i-doit-add-ons/ocs-inventory-ng.md

--- a/docs/de/i-doit-add-ons/jdisc-connector/cloud-kubernetes-import.md
+++ b/docs/de/i-doit-add-ons/jdisc-connector/cloud-kubernetes-import.md
@@ -1,0 +1,52 @@
+---
+title: "Cloud- und Kubernetes-Import"
+description: "Welche Cloud- und Kubernetes-Daten der JDisc-Import in die CMDB schreibt und wie Sie ihn im Profil aktivieren."
+icon:
+status:
+lang: de
+---
+# Cloud- und Kubernetes-Import
+
+Der JDisc-Import kann Cloud- und Kubernetes-Informationen uebernehmen, die JDisc Discovery in Ihrer Infrastruktur erhebt.
+Dieser Artikel beschreibt, welche Cloud- und Kubernetes-Daten der Import in die CMDB schreibt und wie Sie ihn in einem JDisc-Profil aktivieren.
+Diese Funktionen stehen ab i-doit 39 zusammen mit dem JDisc Connector 1.0.5 zur Verfuegung.
+
+## Voraussetzungen
+
+Oeffnen Sie Ihr Importprofil unter **Administration → Import und Schnittstellen → JDisc → JDisc Profile**.
+Aktivieren Sie in der Kategorieauswahl des Profils die gewuenschten Kategorien: **Cloud**, **Kubernetes** und **Cluster-Mitgliedschaften**.
+Ordnen Sie in der Objekttyp-Zuordnung des Profils die relevanten JDisc-Geraetetypen den gewuenschten i-doit-Objekttypen zu.
+Erstellen Sie wie bei jedem Import ein vollstaendiges Backup, bevor Sie ein Profil aendern und ausfuehren.
+
+## AWS- und Cloud-Metadaten
+
+Fuer Amazon-EC2-Instanzen fuellt der Import die globale Kategorie **Cloud** am zugeordneten Objekt, zum Beispiel einem Virtual Server.
+Die Kategorie enthaelt die folgenden Attribute:
+
+-   **Provider:** der Cloud-Provider als Auswahl, zum Beispiel AWS, Azure oder GCP.
+-   **Account:** der AWS-Account beziehungsweise die Subscription der Instanz.
+-   **Region ID:** der technische Regions-Identifier, zum Beispiel `eu-central-1`.
+-   **Region name:** der lesbare Regionsname.
+-   **State:** der Zustand der Instanz als Auswahl, zum Beispiel Running, Stopped, Pending, Stopping oder Terminated.
+
+Object Storage wie Amazon-S3-Buckets wird als neuer Objekttyp **Cloud Storage** importiert, der ebenfalls die Kategorie Cloud traegt.
+
+## Kubernetes-Topologie
+
+Von JDisc erkannte Kubernetes-Ressourcen werden als eigene Objekttypen importiert: **Kubernetes Service**, **Kubernetes Pod** und **Kubernetes Container**.
+Jedes dieser Objekte erhaelt die globale Kategorie **Kubernetes** mit den folgenden Attributen:
+
+-   **Namespace:** der Kubernetes-Namespace der Ressource.
+-   **Workload:** der zugehoerige Workload, zum Beispiel ein Deployment, ReplicaSet oder DaemonSet.
+-   **Kind:** die Art der Ressource, zum Beispiel Service, Deployment, ReplicaSet oder DaemonSet.
+
+Der Cluster wird als Beziehung abgebildet, nicht als Text-Attribut.
+Jedes Kubernetes-Objekt wird ueber die Standardkategorie **Cluster-Mitgliedschaften** zum Mitglied seines Cluster-Objekts.
+Existiert das Cluster-Objekt noch nicht, legt der Import es als Cluster-Objekt an und verknuepft die Mitglieder damit.
+So navigieren Sie von jedem Service, Pod oder Container zu seinem Cluster und vom Cluster zu allen seinen Mitgliedern.
+
+## Weiterfuehrende Themen
+
+-   [JDisc Connector](./index.md)
+-   [JDisc Profile](../../administration/verwaltung/import-und-schnittstellen/jdisc/jdisc-profile.md)
+-   [JDisc Konfiguration](../../administration/verwaltung/import-und-schnittstellen/jdisc/jdisc-konfiguration.md)

--- a/docs/en/i-doit-add-ons/jdisc-connector/cloud-kubernetes-import.md
+++ b/docs/en/i-doit-add-ons/jdisc-connector/cloud-kubernetes-import.md
@@ -1,0 +1,52 @@
+---
+title: "Cloud and Kubernetes Import"
+description: "Which cloud and Kubernetes data the JDisc import writes to the CMDB and how to enable it in a profile."
+icon:
+status:
+lang: en
+---
+# Cloud and Kubernetes Import
+
+The JDisc import can populate cloud and Kubernetes information that JDisc Discovery collects from your infrastructure.
+This article describes which cloud and Kubernetes data the import writes to the CMDB and how to enable it in a JDisc profile.
+These capabilities are available from i-doit 39 together with the JDisc Connector 1.0.5.
+
+## Prerequisites
+
+Open your import profile under **Administration → Import and Interfaces → JDisc → JDisc Profiles**.
+In the category selection of the profile, activate the categories you want to fill: **Cloud**, **Kubernetes**, and **Cluster memberships**.
+In the object type assignment of the profile, map the relevant JDisc device types to the i-doit object types you want to use.
+As with every import, create a complete backup before you change a profile and run it.
+
+## AWS and cloud metadata
+
+For Amazon EC2 instances the import fills the global category **Cloud** on the matched object, for example a Virtual Server.
+The category holds the following attributes:
+
+-   **Provider:** the cloud provider as a selection, for example AWS, Azure, or GCP.
+-   **Account:** the AWS account or subscription the instance belongs to.
+-   **Region ID:** the technical region identifier, for example `eu-central-1`.
+-   **Region name:** the human readable region name.
+-   **State:** the instance state as a selection, for example Running, Stopped, Pending, Stopping, or Terminated.
+
+Object storage such as Amazon S3 buckets is imported as the new object type **Cloud Storage**, which also carries the Cloud category.
+
+## Kubernetes topology
+
+Kubernetes resources that JDisc discovers are imported as dedicated object types: **Kubernetes Service**, **Kubernetes Pod**, and **Kubernetes Container**.
+Each of these objects receives the global category **Kubernetes** with the following attributes:
+
+-   **Namespace:** the Kubernetes namespace of the resource.
+-   **Workload:** the owning workload, for example a Deployment, ReplicaSet, or DaemonSet.
+-   **Kind:** the resource kind, for example Service, Deployment, ReplicaSet, or DaemonSet.
+
+The cluster is modelled as a relation, not as a text attribute.
+Each Kubernetes object becomes a member of its cluster object through the standard category **Cluster memberships**.
+If the cluster object does not exist yet, the import creates it as a Cluster object and links the members to it.
+You can therefore navigate from any service, pod, or container to its cluster, and from the cluster to all of its members.
+
+## Further readings
+
+-   [JDisc Connector](./index.md)
+-   [JDisc Profiles](../../administration/management/import-and-interfaces/jdisc/jdisc-profile.md)
+-   [JDisc Configuration](../../administration/management/import-and-interfaces/jdisc/jdisc-konfiguration.md)


### PR DESCRIPTION
Adds a new article under **i-doit Add-ons → JDisc Connector → Cloud and Kubernetes Import** (EN + DE).

Documents the new JDisc import capabilities:
- AWS cloud metadata (provider, account, region id/name, state) into the new **Cloud** category on EC2/virtual servers, plus the new **Cloud Storage** object type.
- Kubernetes topology (namespace, workload, kind) into the new **Kubernetes** category, with the cluster modelled as a **relation** (standard cluster membership), plus the new **Kubernetes Service/Pod/Container** object types.

Available from i-doit 39 with JDisc Connector 1.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)