### PR TITLE
fix: use Debian/Ubuntu MariaDB socket path in PHP guides

### DIFF
--- a/docs/de/wartung-und-betrieb/php-update.md
+++ b/docs/de/wartung-und-betrieb/php-update.md
@@ -54,7 +54,7 @@ Am Beispiel eines Wechsels von PHP 8.2 auf PHP 8.3 mit PHP-FPM:
     date.timezone = Europe/Berlin
     session.gc_maxlifetime = 604800
     session.cookie_lifetime = 0
-    mysqli.default_socket = /var/lib/mysql/mysql.sock
+    mysqli.default_socket = /var/run/mysqld/mysqld.sock
     ```
     ```shell
     sudo phpenmod -v 8.3 i-doit
@@ -183,7 +183,7 @@ default_socket_timeout = 60
 date.timezone = Europe/Berlin
 session.gc_maxlifetime = 604800
 session.cookie_lifetime = 0
-mysqli.default_socket = /var/lib/mysql/mysql.sock
+mysqli.default_socket = /var/run/mysqld/mysqld.sock
 ```
 
 Aktiviere die Konfiguration für alle SAPIs (CLI und FPM):

--- a/docs/en/installation/manual-installation/ubuntu/index.md
+++ b/docs/en/installation/manual-installation/ubuntu/index.md
@@ -82,7 +82,7 @@ default_socket_timeout = 60
 date.timezone = Europe/Berlin
 session.gc_maxlifetime = 604800
 session.cookie_lifetime = 0
-mysqli.default_socket = /var/lib/mysql/mysql.sock
+mysqli.default_socket = /var/run/mysqld/mysqld.sock
 ```
 <!-- cSpell:enable -->
 The `memory_limit` must be increased if needed, e.g., for very large reports or extensive documents.

--- a/docs/en/maintenance-and-operation/php-update.md
+++ b/docs/en/maintenance-and-operation/php-update.md
@@ -54,7 +54,7 @@ Using the example of switching from PHP 8.2 to PHP 8.3 with PHP-FPM:
     date.timezone = Europe/Berlin
     session.gc_maxlifetime = 604800
     session.cookie_lifetime = 0
-    mysqli.default_socket = /var/lib/mysql/mysql.sock
+    mysqli.default_socket = /var/run/mysqld/mysqld.sock
     ```
     ```shell
     sudo phpenmod -v 8.3 i-doit
@@ -183,7 +183,7 @@ default_socket_timeout = 60
 date.timezone = Europe/Berlin
 session.gc_maxlifetime = 604800
 session.cookie_lifetime = 0
-mysqli.default_socket = /var/lib/mysql/mysql.sock
+mysqli.default_socket = /var/run/mysqld/mysqld.sock
 ```
 
 Enable the configuration for all SAPIs (CLI and FPM):


### PR DESCRIPTION
The "Update PHP (Debian/Ubuntu)" article and the English Ubuntu manual installation page used the Red Hat socket path `/var/lib/mysql/mysql.sock` in the `i-doit.ini` example.

On Debian and Ubuntu the MariaDB/MySQL Unix socket is `/var/run/mysqld/mysqld.sock`, so copying the example as-is produced a "No such file or directory" database connection error in the web interface.

This aligns the affected pages with the Debian/Ubuntu installation pages, which already use the correct path.

Changed:
- `docs/en/maintenance-and-operation/php-update.md` (2x)
- `docs/de/wartung-und-betrieb/php-update.md` (2x)
- `docs/en/installation/manual-installation/ubuntu/index.md` (1x)