### PR TITLE
Fix guest-systems create/update API payload (connected_object)

### DIFF
--- a/docs/de/grundlagen/kategorien/guest-systems.md
+++ b/docs/de/grundlagen/kategorien/guest-systems.md
@@ -73,7 +73,7 @@ Zeigt an, auf welcher Infrastruktur-Ebene die VM ausgeführt wird – beispielsw
         "object": 123,
         "category": "C__CATG__GUEST_SYSTEMS",
         "data": {
-            "object": 456
+            "connected_object": [456]
         }
     },
     "id": 1
@@ -107,7 +107,7 @@ Zeigt an, auf welcher Infrastruktur-Ebene die VM ausgeführt wird – beispielsw
         "category": "C__CATG__GUEST_SYSTEMS",
         "entry": 32,
         "data": {
-            "object": 789
+            "connected_object": [789]
         }
     },
     "id": 3

--- a/docs/en/basics/categories/guest-systems.md
+++ b/docs/en/basics/categories/guest-systems.md
@@ -73,7 +73,7 @@ Shows on which infrastructure layer the VM is executed -- for example, a cluster
         "object": 123,
         "category": "C__CATG__GUEST_SYSTEMS",
         "data": {
-            "object": 456
+            "connected_object": [456]
         }
     },
     "id": 1
@@ -107,7 +107,7 @@ Shows on which infrastructure layer the VM is executed -- for example, a cluster
         "category": "C__CATG__GUEST_SYSTEMS",
         "entry": 32,
         "data": {
-            "object": 789
+            "connected_object": [789]
         }
     },
     "id": 3


### PR DESCRIPTION
## Problem
Issue #1333. The Guest systems category (`C__CATG__GUEST_SYSTEMS`) API examples for **Create an entry** and **Update an entry** documented the data payload as `"data": { "object": <id> }`. i-doit rejects this with:

```
-32603 Internal error: There was an validation error
{ "object": "(unknown) Property 'object' is unknown." }
```

## Fix
The category's connect property is `connected_object` (an object browser), so the payload must be `"data": { "connected_object": [<id>] }`. Corrected in both the Create and Update examples, in the English and German articles.

## Verification
Reproduced against **i-doit 38** with `cmdb.category.save` on `C__CATG__GUEST_SYSTEMS`:

- `data: { "object": <id> }` → `-32603 … Property 'object' is unknown.` (the reported error)
- `data: { "connected_object": [<id>] }` → `success: true, "Category entry successfully saved"`; `cmdb.category.read` returns the linked `connected_object`.

Same result for both create and update. The params-level `object` (the owning host) is unchanged; only the value inside `data` was wrong.

## Files
- `docs/en/basics/categories/guest-systems.md`
- `docs/de/grundlagen/kategorien/guest-systems.md`