### PR TITLE
Document CMDB status IDs and constants

### DIFF
--- a/docs/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status.md
+++ b/docs/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status.md
@@ -9,11 +9,41 @@ lang: de
 
 Unter **Verwaltung → Vordefinierte Inhalte → CMDB-Status** verwaltest du die Status-Werte, die den Lebenszyklus eines Objekts in der CMDB beschreiben. Du kannst die vorhandenen [Status](../../../grundlagen/lebens-und-dokumentationszyklus.md) mit der CMDB-Status-Funktion organisieren und bearbeiten. Darüber hinaus kannst du festlegen, welcher Status einem importierten Objekt zugewiesen wird und ob der Statusfilter angezeigt werden soll.
 
-i-doit liefert bereits Standardwerte wie **In Betrieb**, **Geplant**, **Defekt**, **Außer Betrieb** und **Gespeichert** mit. Du kannst eigene Status-Werte hinzufügen, bestehende umbenennen oder mit einer individuellen Farbe versehen. Über den Statusfilter in den Objekt-Listen lassen sich Objekte nach ihrem aktuellen CMDB-Status filtern. Der CMDB-Status ist unabhängig vom Zustand (normal, archiviert, gelöscht) eines Objekts -- beide Werte ergänzen sich, um den Lebenszyklus vollständig abzubilden.
+i-doit liefert bereits Standardwerte wie **In Betrieb**, **Geplant**, **Defekt**, **Außer Betrieb** und **Gelagert** mit. Du kannst eigene Status-Werte hinzufügen, bestehende umbenennen oder mit einer individuellen Farbe versehen. Über den Statusfilter in den Objekt-Listen lassen sich Objekte nach ihrem aktuellen CMDB-Status filtern. Der CMDB-Status ist unabhängig vom Zustand (normal, archiviert, gelöscht) eines Objekts -- beide Werte ergänzen sich, um den Lebenszyklus vollständig abzubilden.
 
 [![CMDB-Status](../../../assets/images/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status/1-cs.png)](../../../assets/images/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status/1-cs.png)
+
+## IDs und Konstanten
+
+Jeder CMDB-Status besitzt eine numerische **ID** und eine eindeutige **Konstante**. Anders als die Bezeichnung, die übersetzt wird und jederzeit umbenannt werden kann, bleiben diese beiden Werte stabil. Verwende sie immer dann, wenn ein Status außerhalb der Oberfläche referenziert werden muss, beispielsweise in der [API](../../../i-doit-add-ons/api/index.md), in einem Import oder in einer anderen Schnittstelle.
+
+i-doit wird mit den folgenden Status ausgeliefert:
+
+| ID | Konstante | Standardbezeichnung |
+| --- | --- | --- |
+| 1 | `C__CMDB_STATUS__PLANNED` | Geplant |
+| 2 | `C__CMDB_STATUS__ORDERED` | Bestellt |
+| 3 | `C__CMDB_STATUS__DELIVERED` | Geliefert |
+| 4 | `C__CMDB_STATUS__ASSEMBLED` | Montiert |
+| 5 | `C__CMDB_STATUS__TESTED` | Getestet |
+| 6 | `C__CMDB_STATUS__IN_OPERATION` | In Betrieb |
+| 7 | `C__CMDB_STATUS__DEFECT` | Defekt |
+| 8 | `C__CMDB_STATUS__UNDER_REPAIR` | In Reparatur |
+| 9 | `C__CMDB_STATUS__DELIVERED_FROM_REPAIR` | Aus Reparatur geliefert |
+| 10 | `C__CMDB_STATUS__INOPERATIVE` | Außer Betrieb |
+| 11 | `C__CMDB_STATUS__STORED` | Gelagert |
+| 12 | `C__CMDB_STATUS__SCRAPPED` | Verschrottet |
+| 13 | `C__CMDB_STATUS__IDOIT_STATUS` | i-doit Status |
+| 14 | `C__CMDB_STATUS__IDOIT_STATUS_TEMPLATE` | Template |
+
+!!! note
+
+    **In Betrieb**, **Außer Betrieb**, **i-doit Status** und **Template** sind für die interne Verwendung reserviert und können nicht bearbeitet werden. Die API gibt diese vier Status mit `editable: false` zurück.
+
+Status, die du selbst anlegst, erhalten eigene IDs. Die Tabelle oben umfasst daher ausschließlich die ausgelieferten Standardwerte. Um die vollständige Liste einer bestimmten Installation inklusive eigener Status auszulesen, verwende die API-Methode [cmdb.status.read](../../../i-doit-add-ons/api/methoden/v1/cmdb.status.md). Sie gibt ID, Bezeichnung, Konstante und Farbe jedes Status zurück.
 
 ## Siehe auch
 
 - [Lebens- und Dokumentationszyklus](../../../grundlagen/lebens-und-dokumentationszyklus.md) -- Erklärung von Zustand und CMDB-Status
+- [cmdb.status](../../../i-doit-add-ons/api/methoden/v1/cmdb.status.md) -- Alle Status einer Installation über die API auslesen
 - [Kontaktzuweisungsrollen](kontaktzuweisungsrollen.md) -- Weitere vordefinierte Inhalte verwalten

--- a/docs/en/administration/management/predefined-content/cmdb-status.md
+++ b/docs/en/administration/management/predefined-content/cmdb-status.md
@@ -11,7 +11,7 @@ Under **Administration → Predefined Content → CMDB Status**, you manage the 
 
 i-doit already comes with default values such as **in operation**, **planned**, **defect**, **inoperative**, and **stored**. You can add your own status values, rename existing ones, or assign them an individual color. Via the status filter in the object lists, objects can be filtered by their current CMDB status. The CMDB status is independent of the condition (normal, archived, deleted) of an object -- both values complement each other to fully represent the lifecycle.
 
-[![CMDB Status](../../../assets/images/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status/1-cs.png)](../../../assets/images/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status/1-cs.png)
+[![CMDB Status](../../../assets/images/en/system-administration/administration/predefined-content/cmdb-status/1-cs.png)](../../../assets/images/en/system-administration/administration/predefined-content/cmdb-status/1-cs.png)
 
 ## IDs and constants
 

--- a/docs/en/administration/management/predefined-content/cmdb-status.md
+++ b/docs/en/administration/management/predefined-content/cmdb-status.md
@@ -9,11 +9,41 @@ lang: en
 
 Under **Administration → Predefined Content → CMDB Status**, you manage the status values that describe the lifecycle of an object in the CMDB. You can organize and edit the existing [statuses](../../../basics/life-and-documentation-cycle.md) with the CMDB status function. In addition, you can specify which status is assigned to an imported object and whether the status filter should be displayed.
 
-i-doit already comes with default values such as **In operation**, **Planned**, **Defective**, **Out of operation**, and **Stored**. You can add your own status values, rename existing ones, or assign them an individual color. Via the status filter in the object lists, objects can be filtered by their current CMDB status. The CMDB status is independent of the condition (normal, archived, deleted) of an object -- both values complement each other to fully represent the lifecycle.
+i-doit already comes with default values such as **in operation**, **planned**, **defect**, **inoperative**, and **stored**. You can add your own status values, rename existing ones, or assign them an individual color. Via the status filter in the object lists, objects can be filtered by their current CMDB status. The CMDB status is independent of the condition (normal, archived, deleted) of an object -- both values complement each other to fully represent the lifecycle.
 
 [![CMDB Status](../../../assets/images/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status/1-cs.png)](../../../assets/images/de/administration/verwaltung/vordefinierte-inhalte/cmdb-status/1-cs.png)
+
+## IDs and constants
+
+Every CMDB status has a numeric **ID** and a unique **constant**. In contrast to the title, which is translated and can be renamed at any time, these two values remain stable. Use them whenever a status has to be referenced from outside the interface, for example in the [API](../../../i-doit-add-ons/api/index.md), in an import, or in another interface.
+
+i-doit is delivered with the following statuses:
+
+| ID | Constant | Default title |
+| --- | --- | --- |
+| 1 | `C__CMDB_STATUS__PLANNED` | planned |
+| 2 | `C__CMDB_STATUS__ORDERED` | ordered |
+| 3 | `C__CMDB_STATUS__DELIVERED` | delivered |
+| 4 | `C__CMDB_STATUS__ASSEMBLED` | assembled |
+| 5 | `C__CMDB_STATUS__TESTED` | tested |
+| 6 | `C__CMDB_STATUS__IN_OPERATION` | in operation |
+| 7 | `C__CMDB_STATUS__DEFECT` | defect |
+| 8 | `C__CMDB_STATUS__UNDER_REPAIR` | under repair |
+| 9 | `C__CMDB_STATUS__DELIVERED_FROM_REPAIR` | delivered from repair |
+| 10 | `C__CMDB_STATUS__INOPERATIVE` | inoperative |
+| 11 | `C__CMDB_STATUS__STORED` | stored |
+| 12 | `C__CMDB_STATUS__SCRAPPED` | scrapped |
+| 13 | `C__CMDB_STATUS__IDOIT_STATUS` | i-doit Status |
+| 14 | `C__CMDB_STATUS__IDOIT_STATUS_TEMPLATE` | Template |
+
+!!! note
+
+    **In operation**, **inoperative**, **i-doit Status** and **Template** are reserved for internal use and cannot be edited. The API returns these four statuses with `editable: false`.
+
+Statuses that you create yourself are assigned their own IDs, so the table above covers the delivered defaults only. To read the complete list of a specific installation, including your own statuses, use the API method [cmdb.status.read](../../../i-doit-add-ons/api/methods/v1/cmdb.status.md). It returns the ID, title, constant and color of every status.
 
 ## See also
 
 - [Life and Documentation Cycle](../../../basics/life-and-documentation-cycle.md) -- Explanation of condition and CMDB status
+- [cmdb.status](../../../i-doit-add-ons/api/methods/v1/cmdb.status.md) -- Read all statuses of an installation via the API
 - [Contact Assignment Roles](kontaktzuweisungsrollen.md) -- Manage additional predefined content


### PR DESCRIPTION
Fixes #1236

## Problem
The CMDB status article explains how to manage statuses, but it never lists the numeric **IDs** or the **`C__CMDB_STATUS__*` constants**. Anyone who has to address a status from the API, an import or another interface had to log into a running instance and look them up first.

## Change
Adds an **"IDs and constants"** section to both the EN and DE article:

- A table of the 14 delivered statuses: **ID, constant, default title**.
- A note that **in operation, inoperative, i-doit Status and Template** are reserved for internal use and are returned with `editable: false`.
- A pointer to **[cmdb.status.read](https://kb.i-doit.com/en/i-doit-add-ons/api/methods/v1/cmdb.status.html)** for reading the complete per-installation list including custom statuses, plus a "See also" entry.

## Verification
Every value was verified against **i-doit 38**, three independent ways:

1. **`cmdb.status.read`** on a live instance, called once per language so the EN and DE default titles are the ones i-doit actually ships (not hand translations).
2. **Shipped seed data** in `setup/sql/idoit_data.sql`, which contains the same ID to constant to color mapping for all 14 rows. This confirms the IDs are delivered defaults, not artefacts of the test instance.
3. **Source** (`isys_module_system_settings`), which is where the `editable: false` behaviour for `IN_OPERATION` and `INOPERATIVE` comes from, on top of the DB flag for `IDOIT_STATUS` and `IDOIT_STATUS_TEMPLATE`.

Both tables were then diffed programmatically against the live API response: exact match, 14/14 rows, in both languages. All relative links in the two files resolve to existing pages.

## One thing to look at
I also corrected the example status names in the **intro** of both articles, because they listed titles i-doit does not ship and would have contradicted the new table on the same page:

- DE: "Gespeichert" to **"Gelagert"**
- EN: "Defective" to **"defect"**, "Out of operation" to **"inoperative"** (and lower-cased the examples to match the shipped titles)

Happy to drop that part if you would rather keep the intro untouched.

## Not included
The EN article references the DE screenshot (`assets/images/de/...`). That is the separate #1321 screenshot topic, so I left it alone here.