### PR TITLE
Correct SSO login description and name the fallback prerequisite

### DIFF
--- a/docs/de/benutzerauthentifizierung-und-verwaltung/sso-vergleich/openid/google-openid.md
+++ b/docs/de/benutzerauthentifizierung-und-verwaltung/sso-vergleich/openid/google-openid.md
@@ -129,9 +129,27 @@ Das Modul wird automatisch aktiviert.
 </IfModule>
 ```
 
-
 !!! info "Automatische Endpoint-Erkennung"
 Dank `OIDCProviderMetadataURL` erkennt das Modul alle notwendigen Google-Endpoints automatisch. Eine manuelle Angabe einzelner Endpoints ist nicht erforderlich.
+
+!!! warning "`<Location />` schützt auch Login-Seite, Admin Center und API"
+    Mit `Require valid-user` innerhalb von `<Location />` prüft Apache jeden Request, bevor er i-doit erreicht. Ist der Identity Provider nicht verfügbar, sind damit auch die i-doit Login-Seite, das Admin Center und die JSON-RPC-API gesperrt, und der [SSO-Fallback auf lokale Konten](../sso-fallback/index.md) kann nicht greifen.
+
+    Für einen Notzugang lasse `<Location />` weg und begrenze den Schutz auf den SSO-Einsprung. i-doit startet die SSO-Anmeldung ausschließlich bei einem Aufruf mit `?use-sso=1`:
+
+    ```apache
+    <If "%{QUERY_STRING} =~ /(^|&)use-sso=1(&|$)/">
+        AuthType openid-connect
+        Require valid-user
+    </If>
+
+    <Location "/redirect_uri">
+        AuthType openid-connect
+        Require valid-user
+    </Location>
+    ```
+
+    Der zweite Block ist notwendig, weil Google die Redirect-URI mit eigenen Parametern aufruft. Alternativ bleibt `<Location />` geschützt und ein zweiter, nur intern erreichbarer VirtualHost mit demselben `DocumentRoot` und ohne die OIDC-Direktiven dient als Notzugang.
 
 ***
 
@@ -182,4 +200,6 @@ Wenn **Use Domain Part = No** gesetzt ist, wird die vollständige E-Mail-Adresse
 
 ## Ergebnis
 
-Beim nächsten Aufruf von i-doit erscheint automatisch die Google-Anmeldemaske. Nach erfolgreicher Authentifizierung bei Google wird der Benutzer direkt in i-doit eingeloggt — ohne separate i-doit-Passwort-Eingabe.
+Beim nächsten Aufruf von i-doit erscheint die Login-Seite mit der zusätzlichen Option **SSO Login**. Nach einem Klick darauf und erfolgreicher Authentifizierung bei Google wird der Benutzer in i-doit angemeldet, ohne ein i-doit Passwort einzugeben.
+
+Seit i-doit 29 melden sich Benutzer über die einfache URL nicht mehr automatisch an, dadurch bleibt ein sauberer Logout möglich. Um den zusätzlichen Klick zu sparen, rufe i-doit direkt mit `https://<DEINE-SERVER-URL>/?use-sso=1` auf, zum Beispiel als Lesezeichen oder als Startseite des Browsers.

--- a/docs/de/benutzerauthentifizierung-und-verwaltung/sso-vergleich/sso-fallback/index.md
+++ b/docs/de/benutzerauthentifizierung-und-verwaltung/sso-vergleich/sso-fallback/index.md
@@ -15,9 +15,14 @@ Der SSO-Fallback ermöglicht es, dass Benutzer sich auch dann noch mit einem lok
 
 ## Welche Konfiguration ist dazu notwendig?
 
-Keine, i-doit unterstützt den SSO-Fallback standardmäßig. Stelle jedoch sicher, dass mindestens ein lokales i-doit Benutzerkonto mit Administratorrechten existiert, um im Notfall Zugriff zu gewährleisten.
+In i-doit keine, der SSO-Fallback wird standardmäßig unterstützt. Stelle jedoch sicher, dass mindestens ein lokales i-doit Benutzerkonto mit Administratorrechten existiert, um im Notfall Zugriff zu gewährleisten.
 
 Sofern nicht direkt die i-doit URL mit dem Parameter `?use-sso=1` aufgerufen wird, wird die Login-Seite angezeigt, die sowohl die SSO-Option als auch die Möglichkeit zur Anmeldung mit lokalen i-doit Benutzerkonten bietet.
+
+!!! warning "Authentifizierung im Webserver kann den Fallback ausschalten"
+    Der Fallback funktioniert nur, solange der Webserver den Request an i-doit weitergibt. Eine Konfiguration, die den kompletten VirtualHost schützt, zum Beispiel `Require valid-user` innerhalb von `<Location />`, prüft jeden Request vorher: ist der Identity Provider nicht verfügbar, bleiben auch Login-Seite, Admin Center und JSON-RPC-API gesperrt.
+
+    Begrenze den Schutz auf den SSO-Einsprung, also den Aufruf mit `?use-sso=1` samt Callback-Pfad des Moduls, oder stelle einen zweiten, nur intern erreichbaren VirtualHost ohne diesen Schutz bereit. Ein Beispiel steht in [Google Authentifizierung via OpenID](../openid/google-openid.md).
 
 ## Siehe auch
 

--- a/docs/en/user-authentication-and-management/sso-comparison/openid/google-openid.md
+++ b/docs/en/user-authentication-and-management/sso-comparison/openid/google-openid.md
@@ -129,9 +129,27 @@ Open the SSL VirtualHost configuration (default: `/etc/apache2/sites-available/d
 </IfModule>
 ```
 
-
 !!! info "Automatic Endpoint Discovery"
 Thanks to `OIDCProviderMetadataURL`, the module automatically discovers all necessary Google endpoints. Manual configuration of individual endpoints is not required.
+
+!!! warning "`<Location />` also protects the login page, the Admin Center and the API"
+    With `Require valid-user` inside `<Location />`, Apache authenticates every request before it reaches i-doit. If the identity provider is unavailable, the i-doit login page, the Admin Center and the JSON-RPC API are locked out as well, and the [SSO fallback to local accounts](../sso-fallback/index.md) cannot take effect.
+
+    To keep an emergency access, drop `<Location />` and restrict the protection to the SSO entry point instead. i-doit starts the SSO login only when it is called with `?use-sso=1`:
+
+    ```apache
+    <If "%{QUERY_STRING} =~ /(^|&)use-sso=1(&|$)/">
+        AuthType openid-connect
+        Require valid-user
+    </If>
+
+    <Location "/redirect_uri">
+        AuthType openid-connect
+        Require valid-user
+    </Location>
+    ```
+
+    The second block is required because Google calls the redirect URI with its own parameters. As an alternative, keep `<Location />` protected and add a second VirtualHost that is reachable internally only, with the same `DocumentRoot` and without the OIDC directives.
 
 ***
 
@@ -182,4 +200,6 @@ When **Use Domain Part = No** is set, the full email address is expected as the 
 
 ## Result
 
-The next time i-doit is accessed, the Google login screen appears automatically. After successful authentication with Google, the user is logged directly into i-doit — without a separate i-doit password entry.
+The next time i-doit is called, the login page appears with the additional **SSO Login** option. After a click on it and a successful authentication with Google, the user is logged into i-doit without entering an i-doit password.
+
+Since i-doit 29 the plain URL no longer logs users in automatically, which keeps a proper logout possible. To skip the extra click, call i-doit directly with `https://<YOUR-SERVER-URL>/?use-sso=1`, for example as a bookmark or as the browser start page.

--- a/docs/en/user-authentication-and-management/sso-comparison/sso-fallback/index.md
+++ b/docs/en/user-authentication-and-management/sso-comparison/sso-fallback/index.md
@@ -15,9 +15,14 @@ The SSO fallback allows users to still log in with a local i-doit user account e
 
 ## What configuration is required?
 
-None, i-doit supports SSO fallback by default. However, make sure that at least one local i-doit user account with administrator privileges exists to ensure access in case of emergency.
+None inside i-doit, the SSO fallback is supported by default. However, make sure that at least one local i-doit user account with administrator privileges exists to ensure access in case of emergency.
 
 Unless the i-doit URL is called directly with the parameter `?use-sso=1`, the login page is displayed, which offers both the SSO option and the option to log in with local i-doit user accounts.
+
+!!! warning "Web server authentication can switch the fallback off"
+    The fallback works only as long as the web server passes the request on to i-doit. A configuration that protects the entire VirtualHost, for example `Require valid-user` inside `<Location />`, authenticates every request beforehand: if the identity provider is unavailable, the login page, the Admin Center and the JSON-RPC API stay locked out too.
+
+    Restrict the protection to the SSO entry point, meaning the call with `?use-sso=1` plus the callback path of your module, or provide a second VirtualHost without that protection that is reachable internally only. See [Google Authentication via OpenID](../openid/google-openid.md) for an example.
 
 ## See also
 


### PR DESCRIPTION
Correct the SSO login description and name the web server prerequisite for the builtin fallback

The Google OpenID guide promised an automatic login after authenticating with Google, and the SSO fallback page answered the configuration question with a plain "None". Both leave out that a VirtualHost-wide `Require valid-user` authenticates every request before it reaches i-doit, which locks out the login page, the Admin Center and the JSON-RPC API and therefore disables the fallback to local accounts.

### Added

-   Warning on the Google OpenID guide (EN + DE) explaining what `<Location />` with `Require valid-user` covers, plus two alternatives: scope the protection to the SSO entry point with an `<If "%{QUERY_STRING} =~ /(^|&)use-sso=1(&|$)/">` block and a protected callback path, or add a second VirtualHost that is reachable internally only
-   Warning on the SSO fallback page (EN + DE) that web server authentication can switch the fallback off, linking to the OpenID guide for the example

### Changed

-   Result section of the Google OpenID guide (EN + DE): the login page with the SSO Login option appears instead of an automatic login, and `?use-sso=1` is the way to skip the extra click
-   SSO fallback page (EN + DE): the configuration question now answers "None inside i-doit" instead of "None"

### Conditions

By sending this pull request I have read and accept the following conditions:

-   [x] I have read the [code of conduct](../CODE_OF_CONDUCT.md) and accept it.
-   [x] I have read the [contributing guidelines](../CONTRIBUTING.md) and accept them.
-   [x] I have read the [writing guidelines](../GUIDELINES.md) and accept them.
-   [x] I accept that my contribution will be licensed under a [CC BY-SA 4.0 License](../LICENSE).
