### PR TITLE
docs: render licensing step images below the step text

### DIFF
--- a/docs/de/wartung-und-betrieb/lizenzierung.md
+++ b/docs/de/wartung-und-betrieb/lizenzierung.md
@@ -50,6 +50,7 @@ Der **license Token** wird per E-Mail zugeschickt. Die **offline License** wird 
 1. Rufe die i-doit Installation über den Browser auf und logge dich mit den Standard-Benutzerdaten ein. Infos unter [Erstanmeldung](../grundlagen/erstanmeldung.md)
 
 2. Nach dem Login erscheint ein Popup-Fenster, dort wird der license Token eingetragen, der per E-Mail erhalten wurde.
+
     [![Eval Token popup](../assets/images/de/wartung-und-betrieb/lizenzierung/eval-license-popup-online.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/eval-license-popup-online.png)
 
 3. Nach kurzer Zeit erkennt i-doit, dass keine Internetverbindung verfügbar ist und fordert zusätzlich zum **license Token** den **offline license** an.
@@ -67,6 +68,7 @@ Der **license Token** wird per E-Mail zugeschickt. Die **offline License** wird 
 <div class="steps" markdown>
 
 1. Rufe die i-doit Installation über den Browser auf. Um in das [Admin-Center](../administration/admin-center.md) zu gelangen klicke auf den Link in der Anmeldemaske.
+
     [![02-update-login](../assets/images/de/wartung-und-betrieb/lizenzierung/02-update-login.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/02-update-login.png)
 
 2. Als nächstes müssen die Anmeldedaten eingeben werden, die bei der Installation von i-doit für das [Admin-Center](../administration/admin-center.md) vergeben wurden.
@@ -76,12 +78,15 @@ Der **license Token** wird per E-Mail zugeschickt. Die **offline License** wird 
     [![03-update-login-admin-center](../assets/images/de/wartung-und-betrieb/lizenzierung/03-update-login-admin-center.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/03-update-login-admin-center.png)
 
 3. Klicke auf den Reiter **Licenses**.
+
     [![04-update-admin-center-home](../assets/images/de/wartung-und-betrieb/lizenzierung/04-update-admin-center-home.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/04-update-admin-center-home.png)
 
 4. Füge nun den **license Token** in das Textfeld ein.
+
     [![05-update-insert-weblicense-token](../assets/images/de/wartung-und-betrieb/lizenzierung/05-update-insert-weblicense-token.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/05-update-insert-weblicense-token.png)
 
 5. Klicke auf den {++Save & Check++} Button. Nun wird der **License Token** vom Lizenzserver geprüft und i-doit ist lizenziert.
+
     [![06-update-save-and-check](../assets/images/de/wartung-und-betrieb/lizenzierung/06-update-save-and-check.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/06-update-save-and-check.png)
 
 </div>
@@ -93,9 +98,11 @@ Der **license Token** wird per E-Mail zugeschickt. Die **offline License** wird 
 <div class="steps" markdown>
 
 1. Logge dich in das [Kundenportal](https://center.i-doit.com/portal/advanced) ein und kopiere die **offline License** im Reiter **Advanced**.
+
     [![01-update-get-offline-token](../assets/images/de/wartung-und-betrieb/lizenzierung/01-update-get-offline-token.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/01-update-get-offline-token.png)
 
 2. Rufe die i-doit Installation über den Browser auf. Um in das [Admin-Center](../administration/admin-center.md) zu gelangen klicke auf den Link in der Anmeldemaske.
+
     [![02-update-login](../assets/images/de/wartung-und-betrieb/lizenzierung/02-update-login.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/02-update-login.png)
 
 3. Als nächstes müssen die Anmeldedaten eingeben werden, die bei der Installation von i-doit für das [Admin-Center](../administration/admin-center.md) vergeben wurden.
@@ -105,24 +112,31 @@ Der **license Token** wird per E-Mail zugeschickt. Die **offline License** wird 
     [![03-update-login-admin-center](../assets/images/de/wartung-und-betrieb/lizenzierung/03-update-login-admin-center.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/03-update-login-admin-center.png)
 
 4. Klicke auf den Reiter **Licenses**.
+
     [![04-update-admin-center-home](../assets/images/de/wartung-und-betrieb/lizenzierung/04-update-admin-center-home.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/04-update-admin-center-home.png)
 
 5. Füge nun den **license Token** in das Textfeld ein.
+
     [![05-update-insert-weblicense-token](../assets/images/de/wartung-und-betrieb/lizenzierung/05-update-insert-weblicense-token.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/05-update-insert-weblicense-token.png)
 
 6. Klicke auf den {++Save++} Button. **Nicht** auf {--Save & Check--} klicken.
+
     [![06-update-save](../assets/images/de/wartung-und-betrieb/lizenzierung/06-update-save.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/06-update-save.png)
 
 7. Nachdem der License Token gespeichert wurde, klicke auf den **Install new license** Button.
+
     [![07-update-offline-install-new-license](../assets/images/de/wartung-und-betrieb/lizenzierung/07-update-offline-install-new-license.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/07-update-offline-install-new-license.png)
 
 8. Hier wird das Feld angezeigt, in das die gesamte **offline License** kopiert werden muss. Woher du die **offline License** bekommst, kannst du [hier](#wie-erhalte-ich-den-lizenz-token-und-die-offline-lizenz) nachlesen.
+
     [![08-update-offline-insert-offline-license](../assets/images/de/wartung-und-betrieb/lizenzierung/08-update-offline-insert-offline-license.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/08-update-offline-insert-offline-license.png)
 
 9. Anschließend auf den **Add license** Button klicken.
+
     [![09-update-offline-insert-offline-license-add-license](../assets/images/de/wartung-und-betrieb/lizenzierung/09-update-offline-insert-offline-license-add-license.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/09-update-offline-insert-offline-license-add-license.png)
 
 10. Der License Token wird mit dem **offline License** verifiziert und es werden alle damit verbundenen Lizenzen angezeigt.
+
     [![10-update-offline-done](../assets/images/de/wartung-und-betrieb/lizenzierung/10-update-offline-done.png)](../assets/images/de/wartung-und-betrieb/lizenzierung/10-update-offline-done.png)
 
 </div>

--- a/docs/en/maintenance-and-operation/licensing.md
+++ b/docs/en/maintenance-and-operation/licensing.md
@@ -50,6 +50,7 @@ The **license token** is sent by email. The **offline license** can be retrieved
 1. Open the i-doit installation in your browser and log in with the default credentials. More info at [First login](../basics/initial-login.md)
 
 2. After login, a popup window appears where you enter the license token that was received by email.
+
     [![Eval Token popup](../assets/images/en/maintenance-and-operation/licensing/eval-license-popup-online.png)](../assets/images/en/maintenance-and-operation/licensing/eval-license-popup-online.png)
 
 3. After a short time, i-doit detects that no internet connection is available and requests the **offline license** in addition to the **license token**.
@@ -67,6 +68,7 @@ The **license token** is sent by email. The **offline license** can be retrieved
 <div class="steps" markdown>
 
 1. Open the i-doit installation in your browser. To access the [Admin Center](../administration/admin-center.md), click on the link in the login screen.
+
     [![02-update-login](../assets/images/en/maintenance-and-operation/licensing/02-update-login.png)](../assets/images/en/maintenance-and-operation/licensing/02-update-login.png)
 
 2. Next, enter the credentials that were set during the i-doit installation for the [Admin Center](../administration/admin-center.md).
@@ -76,12 +78,15 @@ The **license token** is sent by email. The **offline license** can be retrieved
     [![03-update-login-admin-center](../assets/images/en/maintenance-and-operation/licensing/03-update-login-admin-center.png)](../assets/images/en/maintenance-and-operation/licensing/03-update-login-admin-center.png)
 
 3. Click on the **Licenses** tab.
+
     [![04-update-admin-center-home](../assets/images/en/maintenance-and-operation/licensing/04-update-admin-center-home.png)](../assets/images/en/maintenance-and-operation/licensing/04-update-admin-center-home.png)
 
 4. Paste the **license token** into the text field.
+
     [![05-update-insert-weblicense-token](../assets/images/en/maintenance-and-operation/licensing/05-update-insert-weblicense-token.png)](../assets/images/en/maintenance-and-operation/licensing/05-update-insert-weblicense-token.png)
 
 5. Click the {++Save & Check++} button. The **license token** is now verified by the license server and i-doit is licensed.
+
     [![06-update-save-and-check](../assets/images/en/maintenance-and-operation/licensing/06-update-save-and-check.png)](../assets/images/en/maintenance-and-operation/licensing/06-update-save-and-check.png)
 
 </div>
@@ -93,9 +98,11 @@ The **license token** is sent by email. The **offline license** can be retrieved
 <div class="steps" markdown>
 
 1. Log in to the [customer portal](https://center.i-doit.com/portal/advanced) and copy the **offline license** from the **Advanced** tab.
+
     [![01-update-get-offline-token](../assets/images/en/maintenance-and-operation/licensing/01-update-get-offline-token.png)](../assets/images/en/maintenance-and-operation/licensing/01-update-get-offline-token.png)
 
 2. Open the i-doit installation in your browser. To access the [Admin Center](../administration/admin-center.md), click on the link in the login screen.
+
     [![02-update-login](../assets/images/en/maintenance-and-operation/licensing/02-update-login.png)](../assets/images/en/maintenance-and-operation/licensing/02-update-login.png)
 
 3. Next, enter the credentials that were set during the i-doit installation for the [Admin Center](../administration/admin-center.md).
@@ -105,24 +112,31 @@ The **license token** is sent by email. The **offline license** can be retrieved
     [![03-update-login-admin-center](../assets/images/en/maintenance-and-operation/licensing/03-update-login-admin-center.png)](../assets/images/en/maintenance-and-operation/licensing/03-update-login-admin-center.png)
 
 4. Click on the **Licenses** tab.
+
     [![04-update-admin-center-home](../assets/images/en/maintenance-and-operation/licensing/04-update-admin-center-home.png)](../assets/images/en/maintenance-and-operation/licensing/04-update-admin-center-home.png)
 
 5. Paste the **license token** into the text field.
+
     [![05-update-insert-weblicense-token](../assets/images/en/maintenance-and-operation/licensing/05-update-insert-weblicense-token.png)](../assets/images/en/maintenance-and-operation/licensing/05-update-insert-weblicense-token.png)
 
 6. Click the {++Save++} button. Do **not** click {--Save & Check--}.
+
     [![06-update-save](../assets/images/en/maintenance-and-operation/licensing/06-update-save.png)](../assets/images/en/maintenance-and-operation/licensing/06-update-save.png)
 
 7. After the license token has been saved, click the **Install new license** button.
+
     [![07-update-offline-install-new-license](../assets/images/en/maintenance-and-operation/licensing/07-update-offline-install-new-license.png)](../assets/images/en/maintenance-and-operation/licensing/07-update-offline-install-new-license.png)
 
 8. Here the field is displayed where the entire **offline license** must be pasted. Where to get the **offline license** is described [here](#how-do-i-obtain-the-license-token-and-the-offline-license).
+
     [![08-update-offline-insert-offline-license](../assets/images/en/maintenance-and-operation/licensing/08-update-offline-insert-offline-license.png)](../assets/images/en/maintenance-and-operation/licensing/08-update-offline-insert-offline-license.png)
 
 9. Then click the **Add license** button.
+
     [![09-update-offline-insert-offline-license-add-license](../assets/images/en/maintenance-and-operation/licensing/09-update-offline-insert-offline-license-add-license.png)](../assets/images/en/maintenance-and-operation/licensing/09-update-offline-insert-offline-license-add-license.png)
 
 10. The license token is verified with the **offline license** and all associated licenses are displayed.
+
     [![10-update-offline-done](../assets/images/en/maintenance-and-operation/licensing/10-update-offline-done.png)](../assets/images/en/maintenance-and-operation/licensing/10-update-offline-done.png)
 
 </div>


### PR DESCRIPTION
Fixes the step images on the licensing pages rendering beside the step text instead of below it.

## Problem

Inside the numbered steps (`<div class="steps" markdown>`), several image lines directly followed the step text line without a blank line in between. Python-Markdown then treats the text and the image as a single paragraph, so the image renders inline beside the text instead of as a block below the step.

## Fix

Add a blank line between the step text and its image in each affected step, matching the steps that already render correctly. The image inside the `!!! success` admonition is intentionally left unchanged.

## Pages

* `docs/de/wartung-und-betrieb/lizenzierung.md`
* `docs/en/maintenance-and-operation/licensing.md`

## Notes

* Strict build passes for both the German and the English configuration.
