### PR TITLE
docs(release-39): document behaviour changes shipping with i-doit 39

### DIFF
--- a/docs/de/administration/verwaltung/mandanten-name-verwaltung/einstellungen-mandanten-name.md
+++ b/docs/de/administration/verwaltung/mandanten-name-verwaltung/einstellungen-mandanten-name.md
@@ -190,6 +190,9 @@ Diese Optionen beeinflussen, wie Informationen in der Benutzeroberfläche darges
 
 **Objekttyp Sortierung** — "Alphabetisch" sortiert die Objekttyp-Gruppen und -Typen in der Navigation automatisch. "Manuell" erlaubt eine eigene Reihenfolge über die Objekttyp-Konfiguration.
 
+!!! info "Standardwert ab Version 39"
+    Bei einer **Neuinstallation** von i-doit 39 ist "Alphabetisch" der Standardwert. Bei einem **Update** von einer früheren Version bleibt die bisher eingestellte Sortierung erhalten — die Umstellung wirkt sich dort nicht aus.
+
 ---
 
 ## Maximallänge von Zeichenfolgen

--- a/docs/de/auswertungen/benachrichtigungen.md
+++ b/docs/de/auswertungen/benachrichtigungen.md
@@ -108,6 +108,14 @@ Im linken Navigationsbaum unter **E-Mail-Vorlagen** kannst du den Inhalt der Ben
 | Betreff               | Der Betreff der zu verschickenden Nachricht kann mit Platzhaltern aus dem unteren Bereich der Oberfläche selbst definiert werden.                      |
 | Benachrichtigungstext | Der Text kann, wie auch der Betreff, mit Platzhaltern zusammengestellt werden.                                                                         |
 | Report                | Ein Report kann hier definiert werden, mit dem in der E-Mail die in der Benachrichtigung gefundenen Objektinformationen aufbereitet verschickt werden. |
+| Als HTML senden       | Ja/Nein-Auswahl. Bei **Ja** wird die E-Mail als HTML versendet und HTML-Markup im Vorlagentext dargestellt. Standard ist **Nein**.                     |
+
+!!! info "Als HTML senden -- ab Version 39"
+    Der Schalter ist keine Checkbox, sondern eine **Ja/Nein-Auswahl**, und steht standardmäßig auf **Nein**. Bestehende Vorlagen versenden also weiterhin reine Text-Mails, bis du sie umstellst.
+
+    Beim Umschalten auf **Ja** wechselt zugleich der Editor für den Benachrichtigungstext: Statt des einfachen Textfeldes erscheint ein WYSIWYG-Editor.
+
+    Die Umstellung zwischen HTML- und Text-E-Mails wird **erst nach dem Speichern aktiv**. i-doit blendet dazu einen entsprechenden Hinweis ein, der bis zum Speichern stehen bleibt.
 
 ## Konfiguration des Aufrufs mit CLI
 

--- a/docs/de/grundlagen/kategorien/access.md
+++ b/docs/de/grundlagen/kategorien/access.md
@@ -39,6 +39,36 @@ Die Art des Zugangs – also das verwendete Protokoll oder die Technologie. Dial
 
 Die vollständige Adresse des Zugangs. Hier wird die URL oder der Verbindungsstring eingetragen, z.B. `https://srv-web-01.bhb.local:8443`, `ssh://admin@10.10.1.100` oder `rdp://jumphost.intern.local`. i-doit rendert diesen Wert als klickbaren Link. Achte darauf, das Protokoll-Präfix und ggf. den Port mit anzugeben, damit der Link direkt funktioniert.
 
+#### Platzhaltervariablen und Modifier
+
+Im URL-Feld lassen sich Platzhaltervariablen verwenden, die i-doit beim Aufruf durch die Werte des Objekts ersetzt, z.B. `%objectname%`. Welche Variablen zur Verfügung stehen, zeigt der Info-Button neben dem URL-Feld.
+
+!!! info "Modifier ab Version 39"
+    Ab i-doit 39 kannst du an jede Variable einen **Modifier** anhängen, abgetrennt durch einen senkrechten Strich. Der eingesetzte Wert wird dadurch vor dem Einfügen umgeformt -- nützlich, wenn das Zielsystem die Werte in einer bestimmten Schreibweise erwartet.
+
+| Modifier | Wirkung |
+|---|---|
+| `encode` | URL-Kodierung; Leerzeichen werden zu `+` |
+| `raw-encode` | URL-Kodierung nach RFC 3986; Leerzeichen werden zu `%20` |
+| `lower` | wandelt in Kleinbuchstaben um |
+| `upper` | wandelt in Großbuchstaben um |
+| `slug` | entfernt Sonderzeichen und verbindet die Wörter mit Bindestrichen |
+
+Beispiel für ein Objekt mit dem Namen `Example (with special chars) + !`:
+
+| Variable | Ergebnis |
+|---|---|
+| `%objectname%` | `Example (with special chars) + !` |
+| `%objectname\|encode%` | `Example+%28with+special+chars%29+%2B+%21` |
+| `%objectname\|raw-encode%` | `Example%20%28with%20special%20chars%29%20%2B%20%21` |
+| `%objectname\|lower%` | `example (with special chars) + !` |
+| `%objectname\|upper%` | `EXAMPLE (WITH SPECIAL CHARS) + !` |
+| `%objectname\|slug%` | `Example-with-special-chars` |
+
+Modifier lassen sich kombinieren und werden **von links nach rechts** angewendet: `%objectname\|lower\|slug%` ergibt `example-with-special-chars`.
+
+Die Modifier greifen überall dort, wo Platzhaltervariablen ersetzt werden -- in der Kategorie-Ansicht, in Objekt- und Kategorie-Listen, in Reports, in der QR-Code-Konfiguration und beim Lesen der Kategorie über die API. Ein Anwendungsbeispiel zeigt die [Patch-Manager-Bridge](../../anwendungsfaelle/i-doit-patch-manager-bridge.md).
+
 ### Primärer Zugriff
 
 Kennzeichnet, ob dieser Eintrag der bevorzugte Zugangsweg zum Objekt ist. Dialog-Feld mit den Werten `Ja` und `Nein`. Pro Objekt sollte genau ein Eintrag als primär markiert werden – dieser wird in Übersichten und der Objektliste bevorzugt angezeigt. Typischerweise ist das die Web-Oberfläche oder der am häufigsten genutzte Zugangsweg.

--- a/docs/de/grundlagen/kategorien/s-organization-master-data.md
+++ b/docs/de/grundlagen/kategorien/s-organization-master-data.md
@@ -29,7 +29,7 @@ Typische Anwendungsfälle:
 
 ### Bezeichnung
 
-Der offizielle Name der Organisation, z.B. `synetics GmbH`, `Deutsche Telekom AG` oder `Abteilung Infrastruktur`. Dieser Wert erscheint in der Listenansicht, in Reports und überall dort, wo das Organisations-Objekt referenziert wird. Verwende den vollständigen, offiziellen Firmennamen inklusive Rechtsform, um Verwechslungen zu vermeiden -- insbesondere bei Konzernen mit ähnlich benannten Tochtergesellschaften.
+Der offizielle Name der Organisation, z.B. `i-doit GmbH`, `Deutsche Telekom AG` oder `Abteilung Infrastruktur`. Dieser Wert erscheint in der Listenansicht, in Reports und überall dort, wo das Organisations-Objekt referenziert wird. Verwende den vollständigen, offiziellen Firmennamen inklusive Rechtsform, um Verwechslungen zu vermeiden -- insbesondere bei Konzernen mit ähnlich benannten Tochtergesellschaften.
 
 ### Telefon
 
@@ -87,7 +87,7 @@ Freitext für ergänzende Angaben: Branche, Kundennummer beim Lieferanten, inter
         "object": 200,
         "category": "C__CATS__ORGANIZATION_MASTER_DATA",
         "data": {
-            "title": "synetics GmbH",
+            "title": "i-doit GmbH",
             "telephone": "+49 211 699 31-0",
             "fax": "+49 211 699 31-99",
             "website": "https://www.i-doit.com",

--- a/docs/de/grundlagen/kategorien/s-organization.md
+++ b/docs/de/grundlagen/kategorien/s-organization.md
@@ -29,7 +29,7 @@ Typische Anwendungsfälle:
 
 ### Bezeichnung
 
-Der Name der Organisation, z.B. `synetics GmbH`, `ACME Corp.` oder `IT-Abteilung Standort Berlin`. Dieser Wert erscheint in der Listenansicht und in Reports. Bei externen Organisationen empfiehlt sich der offizielle Firmenname, bei internen Einheiten eine eindeutige Bezeichnung nach interner Nomenklatur.
+Der Name der Organisation, z.B. `i-doit GmbH`, `ACME Corp.` oder `IT-Abteilung Standort Berlin`. Dieser Wert erscheint in der Listenansicht und in Reports. Bei externen Organisationen empfiehlt sich der offizielle Firmenname, bei internen Einheiten eine eindeutige Bezeichnung nach interner Nomenklatur.
 
 ### Telefon
 
@@ -84,7 +84,7 @@ Freitext für zusätzliche Angaben: Branche, Vertragspartner-Nummer, interne Kur
         "object": 200,
         "category": "C__CATS__ORGANIZATION",
         "data": {
-            "title": "synetics GmbH",
+            "title": "i-doit GmbH",
             "telephone": "+49 211 699 31-0",
             "fax": "+49 211 699 31-99",
             "website": "https://www.i-doit.com",

--- a/docs/de/i-doit-add-ons/i-doit-qr-code-printer.md
+++ b/docs/de/i-doit-add-ons/i-doit-qr-code-printer.md
@@ -45,6 +45,9 @@ Bei der globalen Definition befuellst du die QR-Code-Informationen mit folgenden
 
 [![Globale Definition](../assets/images/de/i-doit-add-ons/qr-code-printer/6-qr.png)](../assets/images/de/i-doit-add-ons/qr-code-printer/6-qr.png)
 
+!!! info "Modifier ab Version 39"
+    Ab i-doit 39 lassen sich die Platzhalter mit einem **Modifier** umformen, z.B. `%objectname|slug%`. Die vollständige Liste der Modifier steht bei der [Kategorie Zugriff](../grundlagen/kategorien/access.md#platzhaltervariablen-und-modifier).
+
 ### Primäre Zugriffs URL
 
 Bei dieser Option fliesst ausschließlich die im Objekt hinterlegte URL in den QR-Code ein.

--- a/docs/en/administration/management/tenant-management/tenant-settings.md
+++ b/docs/en/administration/management/tenant-management/tenant-settings.md
@@ -190,6 +190,9 @@ These options affect how information is displayed in the user interface.
 
 **Object type sorting** — "Alphabetical" sorts the object type groups and types in the navigation automatically. "Manual" allows a custom order via the object type configuration.
 
+!!! info "Default value as of version 39"
+    In a **fresh installation** of i-doit 39, "Alphabetical" is the default value. When you **update** from an earlier version, the sorting that is already configured is kept -- the change does not take effect there.
+
 ---
 
 ## Maximum length of strings

--- a/docs/en/basics/categories/access.md
+++ b/docs/en/basics/categories/access.md
@@ -39,6 +39,36 @@ The type of access -- i.e. the protocol or technology used. Dialog+ field with p
 
 The complete address of the access point. Enter the URL or connection string here, e.g. `https://srv-web-01.bhb.local:8443`, `ssh://admin@10.10.1.100`, or `rdp://jumphost.intern.local`. i-doit renders this value as a clickable link. Make sure to include the protocol prefix and, if applicable, the port so that the link works directly.
 
+#### Placeholder variables and modifiers
+
+The URL field accepts placeholder variables that i-doit replaces with the object's values when the link is used, e.g. `%objectname%`. The info button next to the URL field lists the available variables.
+
+!!! info "Modifiers as of version 39"
+    As of i-doit 39 you can append a **modifier** to any variable, separated by a vertical bar. The value is transformed before it is inserted -- useful when the target system expects a particular notation.
+
+| Modifier | Effect |
+|---|---|
+| `encode` | URL encoding; spaces become `+` |
+| `raw-encode` | URL encoding per RFC 3986; spaces become `%20` |
+| `lower` | converts to lower case |
+| `upper` | converts to upper case |
+| `slug` | strips special characters and joins the words with hyphens |
+
+Example for an object named `Example (with special chars) + !`:
+
+| Variable | Result |
+|---|---|
+| `%objectname%` | `Example (with special chars) + !` |
+| `%objectname\|encode%` | `Example+%28with+special+chars%29+%2B+%21` |
+| `%objectname\|raw-encode%` | `Example%20%28with%20special%20chars%29%20%2B%20%21` |
+| `%objectname\|lower%` | `example (with special chars) + !` |
+| `%objectname\|upper%` | `EXAMPLE (WITH SPECIAL CHARS) + !` |
+| `%objectname\|slug%` | `Example-with-special-chars` |
+
+Modifiers can be combined and are applied **from left to right**: `%objectname\|lower\|slug%` yields `example-with-special-chars`.
+
+Modifiers take effect wherever placeholder variables are replaced -- in the category view, in object and category lists, in reports, in the QR code configuration, and when reading the category via the API. The [Patch Manager bridge](../../use-cases/i-doit-patch-manager-bridge.md) shows an example.
+
 ### Primary access
 
 Indicates whether this entry is the preferred access path to the object. Dialog field with values `Yes` and `No`. Exactly one entry per object should be marked as primary -- this entry is displayed prominently in overviews and the object list. Typically, this is the web interface or the most frequently used access path.

--- a/docs/en/basics/categories/s-organization-master-data.md
+++ b/docs/en/basics/categories/s-organization-master-data.md
@@ -29,7 +29,7 @@ Typical use cases:
 
 ### Title
 
-The official name of the organization, e.g. `synetics GmbH`, `Deutsche Telekom AG`, or `Infrastructure Department`. This value appears in the list view, in reports, and everywhere the organization object is referenced. Use the complete, official company name including legal form to avoid confusion -- especially in corporate groups with similarly named subsidiaries.
+The official name of the organization, e.g. `i-doit GmbH`, `Deutsche Telekom AG`, or `Infrastructure Department`. This value appears in the list view, in reports, and everywhere the organization object is referenced. Use the complete, official company name including legal form to avoid confusion -- especially in corporate groups with similarly named subsidiaries.
 
 ### Phone
 
@@ -87,7 +87,7 @@ Free text for additional details: industry, customer number at the supplier, int
         "object": 200,
         "category": "C__CATS__ORGANIZATION_MASTER_DATA",
         "data": {
-            "title": "synetics GmbH",
+            "title": "i-doit GmbH",
             "telephone": "+49 211 699 31-0",
             "fax": "+49 211 699 31-99",
             "website": "https://www.i-doit.com",

--- a/docs/en/basics/categories/s-organization.md
+++ b/docs/en/basics/categories/s-organization.md
@@ -29,7 +29,7 @@ Typical use cases:
 
 ### Title
 
-The name of the organization, e.g. `synetics GmbH`, `ACME Corp.`, or `IT Department Berlin`. This value appears in the list view and in reports. For external organizations, the official company name is recommended; for internal units, a unique title following internal naming conventions.
+The name of the organization, e.g. `i-doit GmbH`, `ACME Corp.`, or `IT Department Berlin`. This value appears in the list view and in reports. For external organizations, the official company name is recommended; for internal units, a unique title following internal naming conventions.
 
 ### Phone
 
@@ -84,7 +84,7 @@ Free text for additional details: industry, contract partner number, internal ab
         "object": 200,
         "category": "C__CATS__ORGANIZATION",
         "data": {
-            "title": "synetics GmbH",
+            "title": "i-doit GmbH",
             "telephone": "+49 211 699 31-0",
             "fax": "+49 211 699 31-99",
             "website": "https://www.i-doit.com",

--- a/docs/en/evaluation/notifications.md
+++ b/docs/en/evaluation/notifications.md
@@ -108,6 +108,14 @@ In the left navigation tree under **Email Templates**, you can globally customiz
 | Subject             | The subject of the message to be sent can be defined using placeholders from the lower area of the interface.                                      |
 | Notification text   | The text can, like the subject, be composed using placeholders.                                                                                    |
 | Report              | A report can be defined here to send the object information found by the notification in a formatted manner within the email.                      |
+| Send as HTML        | Yes/No selection. With **Yes**, the e-mail is sent as HTML and HTML markup in the template text is rendered. The default is **No**.                |
+
+!!! info "Send as HTML -- as of version 39"
+    The control is not a checkbox but a **Yes/No selection**, and it defaults to **No**. Existing templates therefore keep sending plain text e-mails until you switch them over.
+
+    Switching to **Yes** also changes the editor for the notification text: a WYSIWYG editor replaces the plain text field.
+
+    Switching between HTML and plain text e-mails **only takes effect after saving**. i-doit displays a corresponding notice that stays visible until you save.
 
 ## Configuration of the CLI Call
 

--- a/docs/en/i-doit-add-ons/i-doit-qr-code-printer.md
+++ b/docs/en/i-doit-add-ons/i-doit-qr-code-printer.md
@@ -45,6 +45,9 @@ With the global definition, you fill the QR code information using the following
 
 [![Global definition](../assets/images/en/i-doit-add-ons/qr-code-printer/6-qr.png)](../assets/images/en/i-doit-add-ons/qr-code-printer/6-qr.png)
 
+!!! info "Modifiers as of version 39"
+    As of i-doit 39 the placeholders can be transformed with a **modifier**, e.g. `%objectname|slug%`. The complete list of modifiers is documented for the [Access category](../basics/categories/access.md#placeholder-variables-and-modifiers).
+
 ### Primary access URL
 
 With this option, only the URL stored in the object is included in the QR code.

--- a/docs/en/software-development/add-on-development/add-on-metadata.md
+++ b/docs/en/software-development/add-on-development/add-on-metadata.md
@@ -15,7 +15,7 @@ Here we find, among other things, the add-on name, identifier, author, descripti
         "title": "Example add-on",
         "name": "LC__MODULE__EXAMPLE",
         "identifier": "example",
-        "author": "synetics GmbH",
+        "author": "i-doit GmbH",
         "version": "1.0",
         "description": "Example add-on for i-doit",
         "type": "addon",


### PR DESCRIPTION
Documents the user-visible changes of release 39 (due 2026-10-06) that leave existing articles incomplete. Scope was derived from Jira (`project = ID AND fixVersion = "39"`, 70 issues) and cross-checked against the `updates/versions/39/CHANGELOG` in the release branch; each affected path was verified in the repository rather than inferred from ticket titles.

Every addition carries an "as of version 39" / "ab Version 39" marker following the existing KB convention, so the articles remain correct for version 38 readers and this can be merged ahead of the release. German and English are changed in parallel.

## Changes

**Object type sorting (ID-5252)** — `tenant-settings.md` / `einstellungen-mandanten-name.md`
The default becomes "Alphabetical", but **only for fresh installations**; an update keeps the sorting that is already configured. This is stated verbatim in the acceptance criteria and is absent from the ticket summary — without it, every updating customer looks for a change that never happens on their instance.

**Send as HTML in notifications (ID-5947)** — `notifications.md` / `benachrichtigungen.md`
New option in the e-mail templates. Three details come from the source, not from the ticket: it is a Yes/No selection rather than a checkbox, it defaults to **No** (existing templates keep sending plain text), it switches the notification text to a WYSIWYG editor, and the change **only takes effect after saving**.

**Placeholder modifiers in the Access category (ID-12361)** — `access.md`
Placeholder variables now accept the modifiers `encode`, `raw-encode`, `lower`, `upper` and `slug`, combinable and applied left to right. Includes the worked example from the ticket. Cross-referenced from the QR code configuration, which the ticket includes explicitly.

**Company name (ID-12369)** — `s-organization*.md`, `add-on-metadata.md`
`synetics GmbH` → `i-doit GmbH` in illustrative examples only. Deliberately left untouched: internal identifiers (`synetics_flows`, `syneticsgmbh_idoit`, download file names), the SSO/LDAP example domains (`synetics.test`), and the historical copyright header in `vm-provisioning.md`. A blanket search-and-replace would have broken the articles describing permissions for the add-on center.

## Checked, no change needed

- **CLI `report-export --exportPath`** — ID-12512 concerns the export module's "save as" branch in the web UI, not the CLI option; the option is unchanged in the release branch, and the UI function is not documented in the KB.
- **Admin center** (ID-12583) — the article documents only the default upload directories, no free-form paths that the fix would now reject.
- **LDAP archiving** — `deletedUsersBehaviour` is described correctly; the fix restores the documented behaviour rather than changing it.
- **System requirements** — PHP 8.2–8.4, MariaDB 10.6–11.8, identical to version 38.

## Not done

No local build: `mkdocs` is not installed on the authoring machine. Verified instead that the four new relative links resolve, both new anchors match their heading slugs, and the tables containing escaped pipes keep their column count. A build check in CI or by a reviewer would be welcome.

Two occurrences of the old company name remain in `en/i-doit-add-ons/api/methods/v1/idoit.md`, where an API response sample shows the add-on author. Whether the API returns the new name under v39 depends on the add-on manifests rather than the core, so it was left unverified rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBqk8pjAbXWWMMPRJQ5iwo